### PR TITLE
Reworked the config manager/factory + lots of changes to the Format classes

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/Format.java
+++ b/api/src/main/java/at/helpch/chatchat/api/Format.java
@@ -6,8 +6,11 @@ import java.util.List;
 
 public interface Format {
 
-    int getPriority();
+    int priority();
 
-    @NotNull List<String> getParts();
+    @NotNull Format priority(final int priority);
 
+    @NotNull List<String> parts();
+
+    @NotNull Format parts(@NotNull final List<String> parts);
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -23,11 +23,6 @@ public final class ReloadCommand extends BaseCommand {
         plugin.configManager().reload();
 
         var formatsConfig = plugin.configManager().formats();
-        if (formatsConfig == null) {
-            plugin.audiences().sender(sender)
-                    .sendMessage(Component.text("There was an error reading the formats config!", NamedTextColor.RED));
-            return;
-        }
 
         int formats = formatsConfig.formats().size();
         plugin.audiences().sender(sender)

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -28,17 +28,10 @@ public final class WhisperCommand extends BaseCommand {
             return;
         }
 
-        var settingsConfig = plugin.configManager().settings();
+        final var settingsConfig = plugin.configManager().settings();
 
-        final PMFormat senderFormat;
-        final PMFormat receiverFormat;
-        if (settingsConfig == null) {
-            senderFormat = FormatUtils.createDefaultPrivateMessageSenderFormat();
-            receiverFormat = FormatUtils.createDefaultPrivateMessageReceiverFormat();
-        } else {
-            senderFormat = settingsConfig.getSenderFormat();
-            receiverFormat = settingsConfig.getRecieverFormat();
-        }
+        final var senderFormat = settingsConfig.getSenderFormat();
+        final var receiverFormat = settingsConfig.getRecieverFormat();
 
         plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, message));
         plugin.audiences().player(target).sendMessage(FormatUtils.parseFormat(receiverFormat, target, message));

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
@@ -8,6 +8,7 @@ import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 public final class ConfigFactory {
 
@@ -17,16 +18,19 @@ public final class ConfigFactory {
         this.dataFolder = dataFolder;
     }
 
-    public @Nullable ChannelsHolder channels() {
-        return create(ChannelsHolder.class, "channels.yml");
+    public @NotNull ChannelsHolder channels() {
+        final var config = create(ChannelsHolder.class, "channels.yml");
+        return Objects.requireNonNullElseGet(config, ChannelsHolder::new);
     }
 
-    public @Nullable FormatsHolder formats() {
-        return create(FormatsHolder.class, "formats.yml");
+    public @NotNull FormatsHolder formats() {
+        final var config = create(FormatsHolder.class, "formats.yml");
+        return Objects.requireNonNullElseGet(config, FormatsHolder::new);
     }
 
-    public @Nullable SettingsHolder settings() {
-        return create(SettingsHolder.class, "settings.yml");
+    public @NotNull SettingsHolder settings() {
+        final var config = create(SettingsHolder.class, "settings.yml");
+        return Objects.requireNonNullElseGet(config, SettingsHolder::new);
     }
 
     private @Nullable <T> T create(@NotNull final Class<T> clazz, @NotNull final String fileName) {

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.config;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 
@@ -26,7 +25,7 @@ public final class ConfigManager {
     }
 
     // probably shouldn't be null? IDK
-    public @Nullable ChannelsHolder channels() {
+    public @NotNull ChannelsHolder channels() {
         if (channels == null) {
             this.channels = new ConfigFactory(dataFolder).channels();
         }
@@ -34,7 +33,7 @@ public final class ConfigManager {
     }
 
     // probably shouldn't be null? IDK
-    public @Nullable SettingsHolder settings() {
+    public @NotNull SettingsHolder settings() {
         if (settings == null) {
             this.settings = new ConfigFactory(dataFolder).settings();
         }
@@ -42,7 +41,7 @@ public final class ConfigManager {
     }
 
     // probably shouldn't be null? IDK
-    public @Nullable FormatsHolder formats() {
+    public @NotNull FormatsHolder formats() {
         if (formats == null) {
             this.formats = new ConfigFactory(dataFolder).formats();
         }

--- a/plugin/src/main/java/at/helpch/chatchat/config/FormatsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/FormatsHolder.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.format.ChatFormat;
-import at.helpch.chatchat.util.FormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -11,7 +10,7 @@ import java.util.Map;
 public final class FormatsHolder {
 
     private String defaultFormat = "default";
-    private Map<String, ChatFormat> formats = Map.of(defaultFormat, FormatUtils.createDefaultFormat());
+    private Map<String, ChatFormat> formats = Map.of(defaultFormat, ChatFormat.DEFAULT_FORMAT);
 
     public @NotNull String defaultFormat() {
         return defaultFormat;

--- a/plugin/src/main/java/at/helpch/chatchat/config/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/SettingsHolder.java
@@ -1,15 +1,14 @@
 package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.format.PMFormat;
-import at.helpch.chatchat.util.FormatUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 @ConfigSerializable
 public final class SettingsHolder {
-    private PMFormat senderFormat = FormatUtils.createDefaultPrivateMessageSenderFormat();
-    private PMFormat receiverFormat = FormatUtils.createDefaultPrivateMessageReceiverFormat();
+    private PMFormat senderFormat = PMFormat.DEFAULT_SENDER_FORMAT;
+    private PMFormat receiverFormat = PMFormat.DEFAULT_RECEIVER_FORMAT;
 
     public @NonNull PMFormat getSenderFormat() {
         return senderFormat;

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.format;
 
 import at.helpch.chatchat.api.Format;
-import at.helpch.chatchat.util.FormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -11,7 +10,7 @@ import java.util.List;
 @ConfigSerializable
 public final class ChatFormat implements Format {
 
-    public static transient final ChatFormat DEFAULT_FORMAT = FormatUtils.createDefaultFormat();
+    public static transient final ChatFormat DEFAULT_FORMAT = DefaultFormatFactory.createDefaultFormat();
     private int priority = Integer.MAX_VALUE;
     private List<String> parts = Collections.emptyList();
 

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -14,6 +14,14 @@ public final class ChatFormat implements Format {
     private int priority = Integer.MAX_VALUE;
     private List<String> parts = Collections.emptyList();
 
+    // constructor for Configurate
+    public ChatFormat() {}
+
+    private ChatFormat(final int priority, @NotNull final List<String> parts) {
+        this.priority = priority;
+        this.parts = parts;
+    }
+
     @Override
     public int priority() {
         return priority;
@@ -33,9 +41,7 @@ public final class ChatFormat implements Format {
     }
 
     public static @NotNull ChatFormat of(final int priority, @NotNull final List<String> parts) {
-        return new ChatFormat()
-                .priority(priority)
-                .parts(parts);
+        return new ChatFormat(priority, parts);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -34,7 +34,7 @@ public final class ChatFormat implements Format {
 
     @Override
     public @NotNull List<String> parts() {
-        return parts;
+        return List.copyOf(parts);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.format;
 
 import at.helpch.chatchat.api.Format;
+import at.helpch.chatchat.util.FormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -8,28 +9,34 @@ import java.util.Collections;
 import java.util.List;
 
 @ConfigSerializable
-// configurate requires a 0 args constructor, so we use setters for now
 public final class ChatFormat implements Format {
 
+    public static transient final ChatFormat DEFAULT_FORMAT = FormatUtils.createDefaultFormat();
     private int priority = Integer.MAX_VALUE;
     private List<String> parts = Collections.emptyList();
 
     @Override
-    public int getPriority() {
+    public int priority() {
         return priority;
     }
 
-    public void setPriority(final int priority) {
-        this.priority = priority;
+    public @NotNull ChatFormat priority(final int priority) {
+        return of(priority, parts);
     }
 
     @Override
-    public @NotNull List<String> getParts() {
+    public @NotNull List<String> parts() {
         return parts;
     }
 
-    public void setParts(@NotNull final List<String> parts) {
-        this.parts = parts;
+    public @NotNull ChatFormat parts(@NotNull final List<String> parts) {
+        return of(priority, parts);
+    }
+
+    public static @NotNull ChatFormat of(final int priority, @NotNull final List<String> parts) {
+        return new ChatFormat()
+                .priority(priority)
+                .parts(parts);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -27,6 +27,7 @@ public final class ChatFormat implements Format {
         return priority;
     }
 
+    @Override
     public @NotNull ChatFormat priority(final int priority) {
         return of(priority, parts);
     }
@@ -36,6 +37,7 @@ public final class ChatFormat implements Format {
         return parts;
     }
 
+    @Override
     public @NotNull ChatFormat parts(@NotNull final List<String> parts) {
         return of(priority, parts);
     }

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -1,0 +1,21 @@
+package at.helpch.chatchat.format;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+final class DefaultFormatFactory {
+
+    static @NotNull ChatFormat createDefaultFormat() {
+        return ChatFormat.of(1,
+                List.of("<gray>[</gray><color:#3dbbe4>Chat</color><color:#f3af4b>Chat</color><gray>]</gray> %player_name% » %message%"));
+    }
+
+    static @NotNull PMFormat createDefaultPrivateMessageSenderFormat() {
+        return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"));
+    }
+
+    static @NotNull PMFormat createDefaultPrivateMessageReceiverFormat() {
+        return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>:"));
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -14,6 +14,13 @@ public final class PMFormat implements Format {
     public static transient final PMFormat DEFAULT_RECEIVER_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageReceiverFormat();
     private List<String> parts = Collections.emptyList();
 
+    // constructor for Configurate
+    public PMFormat() {}
+
+    private PMFormat(@NotNull final List<String> parts) {
+        this.parts = parts;
+    }
+
     @Override
     public int priority() {
         return 1;
@@ -35,7 +42,7 @@ public final class PMFormat implements Format {
     }
 
     public static @NotNull PMFormat of(@NotNull final List<String> parts) {
-        return new PMFormat().parts(parts);
+        return new PMFormat(parts);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.format;
 
 import at.helpch.chatchat.api.Format;
+import at.helpch.chatchat.util.FormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -8,28 +9,40 @@ import java.util.Collections;
 import java.util.List;
 
 @ConfigSerializable
-public class PMFormat implements Format {
+public final class PMFormat implements Format {
 
+    public static transient final PMFormat DEFAULT_SENDER_FORMAT = FormatUtils.createDefaultPrivateMessageSenderFormat();
+    public static transient final PMFormat DEFAULT_RECEIVER_FORMAT = FormatUtils.createDefaultPrivateMessageReceiverFormat();
     private List<String> parts = Collections.emptyList();
 
     @Override
-    public int getPriority() {
+    public int priority() {
         return 1;
     }
 
     @Override
-    public @NotNull List<String> getParts() {
+    public @NotNull Format priority(final int priority) {
+        return this;
+    }
+
+    @Override
+    public @NotNull List<String> parts() {
         return parts;
     }
 
-    public void setParts(@NotNull final List<String> parts) {
-        this.parts = parts;
+    @Override
+    public @NotNull PMFormat parts(@NotNull final List<String> parts) {
+        return of(parts);
+    }
+
+    public static @NotNull PMFormat of(@NotNull final List<String> parts) {
+        return new PMFormat().parts(parts);
     }
 
     @Override
     public String toString() {
         return "PMFormat{" +
-                "priority=" + getPriority() +
+                "priority=" + priority() +
                 ", parts=" + parts +
                 '}';
     }

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.format;
 
 import at.helpch.chatchat.api.Format;
-import at.helpch.chatchat.util.FormatUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -11,8 +10,8 @@ import java.util.List;
 @ConfigSerializable
 public final class PMFormat implements Format {
 
-    public static transient final PMFormat DEFAULT_SENDER_FORMAT = FormatUtils.createDefaultPrivateMessageSenderFormat();
-    public static transient final PMFormat DEFAULT_RECEIVER_FORMAT = FormatUtils.createDefaultPrivateMessageReceiverFormat();
+    public static transient final PMFormat DEFAULT_SENDER_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageSenderFormat();
+    public static transient final PMFormat DEFAULT_RECEIVER_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageReceiverFormat();
     private List<String> parts = Collections.emptyList();
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -26,17 +26,11 @@ public final class ChatListener implements Listener {
         var user = plugin.usersHolder().getUser(player);
 
         var formatsConfig = plugin.configManager().formats();
+        var formatOptional = FormatUtils.findFormat(player, formatsConfig.formats());
+        var defaultFormat = formatsConfig.formats().get(formatsConfig.defaultFormat());
 
-        ChatFormat format;
-        if (formatsConfig == null) { // config is null, so we use the internal format
-            format = FormatUtils.createDefaultFormat();
-        } else {
-            var formatOptional = FormatUtils.findFormat(player, formatsConfig.formats());
-            var defaultFormat = formatsConfig.formats().get(formatsConfig.defaultFormat());
-
-            // if player doesn't have any perms, find default-format and if no default-format is found use the internal format
-            format = formatOptional.orElseGet(() -> defaultFormat != null ? defaultFormat : FormatUtils.createDefaultFormat());
-        }
+        // if player doesn't have any perms, find default-format and if no default-format is found use the internal format
+        var format = formatOptional.orElseGet(() -> defaultFormat != null ? defaultFormat : FormatUtils.createDefaultFormat());
 
         // this will probably be changed when channels will be added
         var audience = plugin.audiences().players();

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -30,7 +30,7 @@ public final class ChatListener implements Listener {
         var defaultFormat = formatsConfig.formats().get(formatsConfig.defaultFormat());
 
         // if player doesn't have any perms, find default-format and if no default-format is found use the internal format
-        var format = formatOptional.orElseGet(() -> defaultFormat != null ? defaultFormat : FormatUtils.createDefaultFormat());
+        var format = formatOptional.orElseGet(() -> defaultFormat != null ? defaultFormat : ChatFormat.DEFAULT_FORMAT);
 
         // this will probably be changed when channels will be added
         var audience = plugin.audiences().players();

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -23,19 +22,6 @@ public final class FormatUtils {
 
     private FormatUtils() {
         throw new AssertionError("Util classes are not to be instantiated!");
-    }
-
-    public static @NotNull ChatFormat createDefaultFormat() {
-        return ChatFormat.of(1,
-                List.of("<gray>[</gray><color:#3dbbe4>Chat</color><color:#f3af4b>Chat</color><gray>]</gray> %player_name% » %message%"));
-    }
-
-    public static @NotNull PMFormat createDefaultPrivateMessageSenderFormat() {
-        return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"));
-    }
-
-    public static @NotNull PMFormat createDefaultPrivateMessageReceiverFormat() {
-        return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>:"));
     }
 
     public static @NotNull Optional<ChatFormat> findFormat(

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -26,28 +26,16 @@ public final class FormatUtils {
     }
 
     public static @NotNull ChatFormat createDefaultFormat() {
-        var format = new ChatFormat();
-        format.setPriority(1);
-        format.setParts(List.of(
-                "<gray>[</gray><color:#3dbbe4>Chat</color><color:#f3af4b>Chat</color><gray>]</gray> %player_name% » %message%"
-        ));
-        return format;
+        return ChatFormat.of(1,
+                List.of("<gray>[</gray><color:#3dbbe4>Chat</color><color:#f3af4b>Chat</color><gray>]</gray> %player_name% » %message%"));
     }
 
     public static @NotNull PMFormat createDefaultPrivateMessageSenderFormat() {
-        var format = new PMFormat();
-        format.setParts(List.of(
-                "<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"
-        ));
-        return format;
+        return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"));
     }
 
     public static @NotNull PMFormat createDefaultPrivateMessageReceiverFormat() {
-        var format = new PMFormat();
-        format.setParts(List.of(
-                "<gray>%player_name% <yellow> » <gray>you <gray>:"
-        ));
-        return format;
+        return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>:"));
     }
 
     public static @NotNull Optional<ChatFormat> findFormat(
@@ -56,14 +44,14 @@ public final class FormatUtils {
         return formats.entrySet().stream()
                 .filter(entry -> player.hasPermission(FORMAT_PERMISSION + entry.getKey()))
                 .map(Map.Entry::getValue)
-                .min(Comparator.comparingInt(ChatFormat::getPriority)); // lower number = higher priority
+                .min(Comparator.comparingInt(ChatFormat::priority)); // lower number = higher priority
     }
 
     public static @NotNull Component parseFormat(
             @NotNull final Format format,
             @NotNull final Player player,
             @NotNull final String message) {
-        return format.getParts().stream()
+        return format.parts().stream()
                 .map(part -> PlaceholderAPI.setPlaceholders(player, part))
                 .map(part -> part.replace("%message%", message))
                 .map(part -> replaceRecipientPlaceholder(player, part))


### PR DESCRIPTION
Reworked the config factory so that it will now create a default config object if there is something wrong with the config file, this means that when calling any of the getters in the ConfigManager class, the returned type will be NotNull.

As for the changes to the Format classes:

- I've removed the get/set method prefixes here, as they are redundant tbh.

- The format classes are pretty much now immutable, as calling priority(int)/parts(List) will return a newly-created Format object with the changes. the only thing thats not fully mutable is the Configurate part of class... oh well.

- Instead of creating a new default format each time its needed, ive cached them so they can be retrieved easily.

- The default format creator methods have been moved to their own class to remove some clutter from the FormatUtil class
