### PR TITLE
Fixed the recipient placeholders in private messaging

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -30,7 +30,7 @@ public final class WhisperCommand extends BaseCommand {
         final var senderFormat = settingsConfig.getSenderFormat();
         final var receiverFormat = settingsConfig.getRecieverFormat();
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, message));
-        plugin.audiences().player(target).sendMessage(FormatUtils.parseFormat(receiverFormat, target, message));
+        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, target, message));
+        plugin.audiences().player(target).sendMessage(FormatUtils.parseFormat(receiverFormat, sender, target, message));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -68,6 +68,9 @@ public final class FormatUtils {
             player,
             toReplace
                 .replace("%recipient%", player.getName())
+                // This is to support PAPI placeholders for the recipient. Ex: %recipient_player_name%.
+                // I know it can be better and probably needs a complex parser but that requires, time, skills and patience,
+                // none of which I actually have.
                 .replace("%recipient_", "%")
             );
     }


### PR DESCRIPTION
- Added a new parseFormat method that takes in a sender and a recipient
- Removed the recipient parsing of placeholders from the method that doesn't take in a recipient
- Fixed private messages parsing the placeholders just for the sender or receiver depending on the format.

Edit: One "small" problem this has is that it replaces all instances of %recipient_ to % even tho there might be nothing after it. We would need an entire parser for this to be fixed, similar to what PAPI has I guess.