### PR TITLE
Small changes and improvements + start of PAPI Expansion.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ adventure-platform = "4.0.1"
 # Other
 configurate = "4.1.2"
 cmds = "2.0.0-SNAPSHOT"
-papi = "2.10.10"
+papi = "2.11.1"
 
 [libraries]
 # Minecraft

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -36,11 +36,15 @@ public final class ChatChatPlugin extends JavaPlugin {
                 new PlayerListener(this),
                 new ChatListener(this)
         ).forEach(listener -> getServer().getPluginManager().registerEvents(listener, this));
+
+        getLogger().info("Plugin enabled successfully!");
     }
 
     @Override
     public void onDisable() {
         audiences.close();
+
+        getLogger().info("Plugin disabled successfully!");
     }
 
     public @NotNull ConfigManager configManager() {

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -8,6 +8,7 @@ import at.helpch.chatchat.command.WhisperCommand;
 import at.helpch.chatchat.config.ConfigManager;
 import at.helpch.chatchat.listener.ChatListener;
 import at.helpch.chatchat.listener.PlayerListener;
+import at.helpch.chatchat.placeholder.ChatPlaceholders;
 import at.helpch.chatchat.user.UsersHolder;
 import dev.triumphteam.annotations.BukkitMain;
 import dev.triumphteam.cmd.bukkit.BukkitCommandManager;
@@ -36,6 +37,8 @@ public final class ChatChatPlugin extends JavaPlugin {
                 new PlayerListener(this),
                 new ChatListener(this)
         ).forEach(listener -> getServer().getPluginManager().registerEvents(listener, this));
+
+        new ChatPlaceholders(this).register();
 
         getLogger().info("Plugin enabled successfully!");
     }

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -7,7 +7,6 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 @ConfigSerializable
 public final class ChatChannel implements Channel {

--- a/plugin/src/main/java/at/helpch/chatchat/command/ChatChatCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ChatChatCommand.java
@@ -2,7 +2,6 @@ package at.helpch.chatchat.command;
 
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
-import net.md_5.bungee.api.chat.BaseComponent;
 
 @Command("chatchat")
 public abstract class ChatChatCommand extends BaseCommand {

--- a/plugin/src/main/java/at/helpch/chatchat/command/MainCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/MainCommand.java
@@ -1,8 +1,6 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import dev.triumphteam.cmd.core.BaseCommand;
-import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.Default;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -1,8 +1,6 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import dev.triumphteam.cmd.core.BaseCommand;
-import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.SubCommand;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -7,6 +7,7 @@ import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.Default;
+import dev.triumphteam.cmd.core.annotation.Join;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -24,7 +25,7 @@ public final class WhisperCommand extends BaseCommand {
 
     @Default
     @Permission(MESSAGE_PERMISSION)
-    public void whisperCommand(final Player sender, final Player target, final String message) {
+    public void whisperCommand(final Player sender, final Player target, @Join final String message) {
         final var settingsConfig = plugin.configManager().settings();
 
         final var senderFormat = settingsConfig.getSenderFormat();

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -1,15 +1,12 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.format.PMFormat;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.Default;
 import dev.triumphteam.cmd.core.annotation.Join;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,9 +27,6 @@ public final class WhisperCommand extends BaseCommand {
 
         final var senderFormat = settingsConfig.getSenderFormat();
         final var receiverFormat = settingsConfig.getRecieverFormat();
-
-
-        final var usersHolder = plugin.usersHolder();
 
         plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, target, message));
         plugin.audiences().player(target).sendMessage(FormatUtils.parseFormat(receiverFormat, sender, target, message));

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -22,13 +22,13 @@ public final class WhisperCommand extends BaseCommand {
 
     @Default
     @Permission(MESSAGE_PERMISSION)
-    public void whisperCommand(final Player sender, final Player target, @Join final String message) {
+    public void whisperCommand(final Player sender, final Player recipient, @Join final String message) {
         final var settingsConfig = plugin.configManager().settings();
 
         final var senderFormat = settingsConfig.getSenderFormat();
-        final var receiverFormat = settingsConfig.getRecieverFormat();
+        final var recipientFormat = settingsConfig.getRecipientFormat();
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, target, message));
-        plugin.audiences().player(target).sendMessage(FormatUtils.parseFormat(receiverFormat, sender, target, message));
+        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, recipient, message));
+        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(recipientFormat, sender, recipient, message));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/config/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/SettingsHolder.java
@@ -8,13 +8,13 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 @ConfigSerializable
 public final class SettingsHolder {
     private PMFormat senderFormat = PMFormat.DEFAULT_SENDER_FORMAT;
-    private PMFormat receiverFormat = PMFormat.DEFAULT_RECEIVER_FORMAT;
+    private PMFormat recipientFormat = PMFormat.DEFAULT_RECIPIENT_FORMAT;
 
     public @NonNull PMFormat getSenderFormat() {
         return senderFormat;
     }
 
-    public @NotNull PMFormat getRecieverFormat() {
-        return receiverFormat;
+    public @NotNull PMFormat getRecipientFormat() {
+        return recipientFormat;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -12,10 +12,10 @@ final class DefaultFormatFactory {
     }
 
     static @NotNull PMFormat createDefaultPrivateMessageSenderFormat() {
-        return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"));
+        return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>: %message%"));
     }
 
     static @NotNull PMFormat createDefaultPrivateMessageRecipientFormat() {
-        return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>:"));
+        return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>: %message%"));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -15,7 +15,7 @@ final class DefaultFormatFactory {
         return PMFormat.of(List.of("<gray>you <yellow> » <gray>%recipient_player_name% <gray>:"));
     }
 
-    static @NotNull PMFormat createDefaultPrivateMessageReceiverFormat() {
+    static @NotNull PMFormat createDefaultPrivateMessageRecipientFormat() {
         return PMFormat.of(List.of("<gray>%player_name% <yellow> » <gray>you <gray>:"));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -11,7 +11,7 @@ import java.util.List;
 public final class PMFormat implements Format {
 
     public static transient final PMFormat DEFAULT_SENDER_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageSenderFormat();
-    public static transient final PMFormat DEFAULT_RECEIVER_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageReceiverFormat();
+    public static transient final PMFormat DEFAULT_RECIPIENT_FORMAT = DefaultFormatFactory.createDefaultPrivateMessageRecipientFormat();
     private List<String> parts = Collections.emptyList();
 
     // constructor for Configurate

--- a/plugin/src/main/java/at/helpch/chatchat/listener/PlayerListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/PlayerListener.java
@@ -1,8 +1,6 @@
 package at.helpch.chatchat.listener;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.channel.ChatChannel;
-import at.helpch.chatchat.user.UsersHolder;
 import at.helpch.chatchat.util.ChannelUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;

--- a/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
+++ b/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
@@ -1,0 +1,83 @@
+package at.helpch.chatchat.placeholder;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.channel.ChatChannel;
+import at.helpch.chatchat.util.ChannelUtils;
+import java.util.List;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+public final class ChatPlaceholders extends PlaceholderExpansion {
+    private final ChatChatPlugin plugin;
+
+    public ChatPlaceholders(@NotNull final ChatChatPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "chatchat";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return plugin.getDescription().getAuthors().get(0);
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public @NotNull List<String> getPlaceholders() {
+        return List.of(
+            "%chatchat_channel_name%",
+            "%chatchat_channel_prefix%"
+        );
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(final OfflinePlayer offlinePlayer, @NotNull final String input) {
+        final var params = input.split("_");
+
+        if (offlinePlayer == null) {
+            return "";
+        }
+
+        if (!offlinePlayer.isOnline()) {
+            return "";
+        }
+
+        final var player = offlinePlayer.getPlayer();
+
+        if (player == null) {
+            return "";
+        }
+
+        final var user = plugin.usersHolder().getUser(player);
+
+        if (params.length < 2) {
+            return null;
+        }
+
+        if (params[0].equals("channel")) {
+            switch (params[1]) {
+                case "name":
+                    // I know unchecked cast etc, but this will al be fixed or at least Kaliber said he'll make finding channel names easier.
+                    return ChannelUtils.findChannelName(plugin.configManager().channels().channels(), (ChatChannel) user.channel()).orElse("");
+                case "prefix":
+                    return user.channel().channelPrefix();
+            }
+
+        }
+
+        return null;
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -38,14 +38,9 @@ public final class ChannelUtils {
         @NotNull final Map<String, ChatChannel> channels,
         @NotNull final ChatChannel channel
     ) {
-        for (Map.Entry<String, ChatChannel> entry : channels.entrySet()){
-            if (!entry.getValue().equals(channel)) {
-                continue;
-            }
-
-            return Optional.of(entry.getKey());
-        }
-
-        return Optional.empty();
+        return channels.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(channel))
+            .map(Map.Entry::getKey)
+            .findFirst();
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -33,4 +33,19 @@ public final class ChannelUtils {
                 .filter(channel -> input.startsWith(channel.messagePrefix()))
                 .findFirst();
     }
+
+    public static @NotNull Optional<String> findChannelName(
+        @NotNull final Map<String, ChatChannel> channels,
+        @NotNull final ChatChannel channel
+    ) {
+        for (Map.Entry<String, ChatChannel> entry : channels.entrySet()){
+            if (!entry.getValue().equals(channel)) {
+                continue;
+            }
+
+            return Optional.of(entry.getKey());
+        }
+
+        return Optional.empty();
+    }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -58,12 +58,12 @@ public final class FormatUtils {
     public static @NotNull Component parseFormat(
         @NotNull final Format format,
         @NotNull final Player player,
-        @NotNull final Player receiver,
+        @NotNull final Player recipient,
         @NotNull final String message) {
         return format.parts().stream()
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
             .map(part -> part.replace("%message%", message))
-            .map(part -> replaceRecipientPlaceholder(receiver, part))
+            .map(part -> replaceRecipientPlaceholder(recipient, part))
             .map(FormatUtils::parseToMiniMessage)
             .collect(Component.toComponent());
     }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -50,7 +50,6 @@ public final class FormatUtils {
         return format.parts().stream()
                 .map(part -> PlaceholderAPI.setPlaceholders(player, part))
                 .map(part -> part.replace("%message%", message))
-                .map(part -> part.replace("%channel_prefix%", channel.channelPrefix()))
                 .map(FormatUtils::parseToMiniMessage)
                 .collect(Component.toComponent());
     }
@@ -62,8 +61,8 @@ public final class FormatUtils {
         @NotNull final String message) {
         return format.parts().stream()
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
-            .map(part -> part.replace("%message%", message))
             .map(part -> replaceRecipientPlaceholder(recipient, part))
+            .map(part -> part.replace("%message%", message))
             .map(FormatUtils::parseToMiniMessage)
             .collect(Component.toComponent());
     }

--- a/plugin/src/main/resources/formats.yml
+++ b/plugin/src/main/resources/formats.yml
@@ -3,7 +3,7 @@ formats:
   default:
     priority: 2 # if we have multiple formats which takes priority
     format: # list of all the segments of the format, supports unlimited amount of segments
-      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%channel_prefix%</hover></click>'
+      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%chatchat_channel_prefix%</hover></click>'
       - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> [%vault_group%]</hover>'
       - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> %player_displayname%</hover>'
       - '<hover:show_text:"Cool diver tooltip here"> ></hover>'
@@ -13,7 +13,7 @@ formats:
   staff: # user needs chatchat.format.staff
     priority: 1 # if we have multiple formats which takes priority
     format: # list of all the segments of the format, supports unlimited amount of segments
-      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%channel_prefix%</hover></click>'
+      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%chatchat_channel_prefix%</hover></click>'
       - '<hover:show_text:"Hey look, i am staff<newline>Some new line">  [STAFF]</hover>'
       - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> %player_displayname%</hover>'
       - '<hover:show_text:"Cool diver tooltip here"> ></hover>'


### PR DESCRIPTION
- Added a plugin enable and plugin disable message to the console
- Fixed whisper message being limited to 1 word (in this case a word means any chat until a space)
- Removed a bunch of unused imports
- Removed unused variable
- Renamed "receiver" to recipient everywhere to make it more consistent
- Added the %message% placeholder in the default format. This is mostly to help while we still work on the plugin because I Do know all default formats will be reworked before release
- Started work on an internal PlaceholderAPI expansion. Currently only has 2 placeholder.
- Bumped PlaceholderAPI dependency version to latest PAPI release.

That's about it. I tried to keep the commit naming very useful as well so you can tell what commit does what.