### PR TITLE
Fixed MiniMessage tags being parsed in messages sent by users (both private and public messages)

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -47,8 +47,18 @@ public final class ReplyCommand extends BaseCommand {
         final var senderFormat = settingsConfig.getSenderFormat();
         final var recipientFormat = settingsConfig.getRecipientFormat();
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, recipient, message));
-        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(recipientFormat, sender, recipient, message));
+        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
+            senderFormat,
+            sender,
+            recipient,
+            Component.text(message)
+        ));
+        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(
+            recipientFormat,
+            sender,
+            recipient,
+            Component.text(message)
+        ));
 
         user.lastMessagedUser(recipientUser);
         recipientUser.lastMessagedUser(user);

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -38,8 +38,18 @@ public final class WhisperCommand extends BaseCommand {
         final var senderFormat = settingsConfig.getSenderFormat();
         final var recipientFormat = settingsConfig.getRecipientFormat();
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(senderFormat, sender, recipient, message));
-        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(recipientFormat, sender, recipient, message));
+        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
+            senderFormat,
+            sender,
+            recipient,
+            Component.text(message)
+        ));
+        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(
+            recipientFormat,
+            sender,
+            recipient,
+            Component.text(message)
+        ));
 
         final var usersHolder = plugin.usersHolder();
         final var user = usersHolder.getUser(sender);

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -6,6 +6,7 @@ import at.helpch.chatchat.api.event.ChatChatEvent;
 import at.helpch.chatchat.util.ChannelUtils;
 import at.helpch.chatchat.util.FormatUtils;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -63,7 +64,11 @@ public final class ChatListener implements Listener {
             return;
         }
 
-        chatEvent.recipients().sendMessage(
-            FormatUtils.parseFormat(chatEvent.format(), player, channel, chatEvent.message()));
+        chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
+            chatEvent.format(),
+            player,
+            channel,
+            Component.text(chatEvent.message())
+        ));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -67,7 +67,6 @@ public final class ChatListener implements Listener {
         chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
             chatEvent.format(),
             player,
-            channel,
             Component.text(chatEvent.message())
         ));
     }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -22,13 +22,21 @@ import java.util.Optional;
 
 public final class FormatUtils {
 
-    private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?");
-    private static final String URL_PERMISSION = "chatchat.url";
-    private static final TextReplacementConfig URL_REPLACER = TextReplacementConfig.builder()
-        .match(FormatUtils.DEFAULT_URL_PATTERN)
-        .replacement(builder -> builder.clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, builder.content())))
+    static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
+    static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
+
+    private static final TextReplacementConfig URL_REPLACER_CONFIG = TextReplacementConfig.builder()
+        .match(DEFAULT_URL_PATTERN)
+        .replacement(builder -> {
+            String clickUrl = builder.content();
+            if (!URL_SCHEME_PATTERN.matcher(clickUrl).find()) {
+                clickUrl = "https://" + clickUrl;
+            }
+            return builder.clickEvent(ClickEvent.openUrl(clickUrl));
+        })
         .build();
 
+    private static final String URL_PERMISSION = "chatchat.url";
     private static final String FORMAT_PERMISSION = "chatchat.format.";
 
 
@@ -65,7 +73,7 @@ public final class FormatUtils {
             .map(part -> FormatUtils.parseToMiniMessage(part,
                 Placeholder.component("message", !player.hasPermission(URL_PERMISSION)
                     ? message
-                    : message.asComponent().replaceText(URL_REPLACER))))
+                    : message.asComponent().replaceText(URL_REPLACER_CONFIG))))
             .collect(Component.toComponent());
     }
 
@@ -80,7 +88,7 @@ public final class FormatUtils {
             .map(part -> FormatUtils.parseToMiniMessage(part,
                 Placeholder.component("message", !player.hasPermission(URL_PERMISSION)
                     ? message
-                    : message.asComponent().replaceText(URL_REPLACER))))
+                    : message.asComponent().replaceText(URL_REPLACER_CONFIG))))
             .collect(Component.toComponent());
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -6,6 +6,8 @@ import at.helpch.chatchat.config.FormatsHolder;
 import at.helpch.chatchat.format.ChatFormat;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.ComponentLike;
+import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
@@ -46,24 +48,36 @@ public final class FormatUtils {
             @NotNull final Format format,
             @NotNull final Player player,
             @NotNull final Channel channel,
-            @NotNull final String message) {
+            @NotNull final ComponentLike message) {
         return format.parts().stream()
-                .map(part -> PlaceholderAPI.setPlaceholders(player, part))
-                .map(part -> part.replace("%message%", message))
-                .map(FormatUtils::parseToMiniMessage)
-                .collect(Component.toComponent());
+            .map(part -> PlaceholderAPI.setPlaceholders(player, part))
+            .map(FormatUtils::parseToMiniMessage)
+            .map(component -> component.replaceText(
+                TextReplacementConfig
+                    .builder()
+                    .matchLiteral("%message%")
+                    .replacement(message)
+                    .build()
+            ))
+            .collect(Component.toComponent());
     }
 
     public static @NotNull Component parseFormat(
         @NotNull final Format format,
         @NotNull final Player player,
         @NotNull final Player recipient,
-        @NotNull final String message) {
+        @NotNull final ComponentLike message) {
         return format.parts().stream()
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
             .map(part -> replaceRecipientPlaceholder(recipient, part))
-            .map(part -> part.replace("%message%", message))
             .map(FormatUtils::parseToMiniMessage)
+            .map(component -> component.replaceText(
+                TextReplacementConfig
+                    .builder()
+                    .matchLiteral("%message%")
+                    .replacement(message)
+                    .build()
+            ))
             .collect(Component.toComponent());
     }
 


### PR DESCRIPTION
As the title mentions, we used to parse the message sent by an user just like it was part of the format so minimessage tags would be parsed. This would allow everyone to use tags like <rainbow> in their messages.