### PR TITLE
some changes to the config / format+channels

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/Channel.java
+++ b/api/src/main/java/at/helpch/chatchat/api/Channel.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 public interface Channel {
 
+    @NotNull String name();
+
     @NotNull String messagePrefix();
 
     @NotNull String channelPrefix();

--- a/api/src/main/java/at/helpch/chatchat/api/Format.java
+++ b/api/src/main/java/at/helpch/chatchat/api/Format.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 public interface Format {
 
+    @NotNull String name();
+
+    @NotNull Format name(@NotNull final String name);
+
     int priority();
 
     @NotNull Format priority(final int priority);

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -69,8 +69,6 @@ public final class ChatChatPlugin extends JavaPlugin {
 
     private void registerCommands() {
         final var commandManager = BukkitCommandManager.create(this);
-        commandManager.registerSuggestion(SuggestionKey.of("players"), ((sender, context) ->
-                Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList())));
 
         List.of(
                 new MainCommand(this),

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -5,40 +5,37 @@ import at.helpch.chatchat.api.User;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-import java.util.Collections;
 import java.util.List;
 
 @ConfigSerializable
 public final class ChatChannel implements Channel {
 
-    private String messagePrefix = "";
+    private final String name;
 
-    private String toggleCommand = "";
+    private final String messagePrefix;
 
-    private String channelPrefix = "";
+    private final String toggleCommand;
 
-    private transient List<User> audience = Collections.emptyList();
+    private final String channelPrefix;
 
-    // Configurate constructor
-    public ChatChannel() {}
+    private final List<User> audience;
 
-    private ChatChannel(
+    public ChatChannel(
+            @NotNull final String name,
             @NotNull final String messagePrefix,
             @NotNull final String toggleCommand,
             @NotNull final String channelPrefix,
             @NotNull final List<User> audience) {
+        this.name = name;
         this.messagePrefix = messagePrefix;
         this.toggleCommand = toggleCommand;
         this.channelPrefix = channelPrefix;
         this.audience = audience;
     }
 
-    public static @NotNull ChatChannel of(
-            @NotNull final String messagePrefix,
-            @NotNull final String toggleCommand,
-            @NotNull final String channelPrefix,
-            @NotNull final List<User> audience) {
-        return new ChatChannel(messagePrefix, toggleCommand, channelPrefix, audience);
+    @Override
+    public @NotNull String name() {
+        return name;
     }
 
     @Override
@@ -75,7 +72,8 @@ public final class ChatChannel implements Channel {
     @Override
     public String toString() {
         return "ChatChannel{" +
-                "messagePrefix='" + messagePrefix + '\'' +
+                "name=" + name +
+                ", messagePrefix='" + messagePrefix + '\'' +
                 ", toggleCommand='" + toggleCommand + '\'' +
                 ", channelPrefix='" + channelPrefix + '\'' +
                 ", audience=" + audience +

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.channel;
 
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.User;
+import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -9,6 +10,8 @@ import java.util.List;
 
 @ConfigSerializable
 public final class ChatChannel implements Channel {
+
+    private static ChatChannel defaultChannel = DefaultConfigObjects.createDefaultChannel();
 
     private final String name;
 
@@ -56,6 +59,14 @@ public final class ChatChannel implements Channel {
     @Override
     public @NotNull String commandName() {
         return toggleCommand;
+    }
+
+    public static @NotNull ChatChannel defaultChannel() {
+        return defaultChannel;
+    }
+
+    public static void defaultChannel(@NotNull final ChatChannel toSet) {
+        defaultChannel = toSet;
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -25,7 +25,7 @@ public final class WhisperCommand extends BaseCommand {
 
     @Default
     @Permission(MESSAGE_PERMISSION)
-    public void whisperCommand(final Player sender, @Suggestion("players") final Player recipient, @Join final String message) {
+    public void whisperCommand(final Player sender, final Player recipient, @Join final String message) {
 
         if (sender.equals(recipient)) {
             plugin.audiences().player(sender).sendMessage(

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
@@ -1,5 +1,14 @@
 package at.helpch.chatchat.config;
 
+import at.helpch.chatchat.channel.ChatChannel;
+import at.helpch.chatchat.config.holders.ChannelsHolder;
+import at.helpch.chatchat.config.holders.FormatsHolder;
+import at.helpch.chatchat.config.holders.SettingsHolder;
+import at.helpch.chatchat.config.mapper.ChannelMapper;
+import at.helpch.chatchat.config.mapper.ChatFormatMapper;
+import at.helpch.chatchat.config.mapper.PMFormatMapper;
+import at.helpch.chatchat.format.ChatFormat;
+import at.helpch.chatchat.format.PMFormat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.yaml.NodeStyle;
@@ -61,7 +70,12 @@ public final class ConfigFactory {
     private @NotNull YamlConfigurationLoader loader(@NotNull final Path path) {
         return YamlConfigurationLoader.builder()
                 .path(path)
-                .defaultOptions(options -> options.shouldCopyDefaults(true).header("https://wiki.helpch.at"))
+                .defaultOptions(options -> options.shouldCopyDefaults(true)
+                        .header("https://wiki.helpch.at")
+                        .serializers(build -> build
+                                .register(ChatFormat.class, new ChatFormatMapper())
+                                .register(ChatChannel.class, new ChannelMapper())
+                                .register(PMFormat.class, new PMFormatMapper())))
                 .nodeStyle(NodeStyle.BLOCK)
                 .indent(2)
                 .build();

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -1,5 +1,8 @@
 package at.helpch.chatchat.config;
 
+import at.helpch.chatchat.config.holders.ChannelsHolder;
+import at.helpch.chatchat.config.holders.FormatsHolder;
+import at.helpch.chatchat.config.holders.SettingsHolder;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
@@ -24,7 +27,6 @@ public final class ConfigManager {
         formats();
     }
 
-    // probably shouldn't be null? IDK
     public @NotNull ChannelsHolder channels() {
         if (channels == null) {
             this.channels = new ConfigFactory(dataFolder).channels();
@@ -32,7 +34,6 @@ public final class ConfigManager {
         return this.channels;
     }
 
-    // probably shouldn't be null? IDK
     public @NotNull SettingsHolder settings() {
         if (settings == null) {
             this.settings = new ConfigFactory(dataFolder).settings();
@@ -40,7 +41,6 @@ public final class ConfigManager {
         return this.settings;
     }
 
-    // probably shouldn't be null? IDK
     public @NotNull FormatsHolder formats() {
         if (formats == null) {
             this.formats = new ConfigFactory(dataFolder).formats();

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -1,8 +1,11 @@
 package at.helpch.chatchat.config;
 
+import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.config.holders.ChannelsHolder;
 import at.helpch.chatchat.config.holders.FormatsHolder;
 import at.helpch.chatchat.config.holders.SettingsHolder;
+import at.helpch.chatchat.format.ChatFormat;
+import at.helpch.chatchat.format.DefaultFormatFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
@@ -22,9 +25,16 @@ public final class ConfigManager {
         channels = null;
         formats = null;
         settings = null;
+
         channels();
+        final var defaultChannel = channels.channels().getOrDefault(channels.defaultChannel(), DefaultConfigObjects.createDefaultChannel());
+        ChatChannel.defaultChannel(defaultChannel);
+
         settings();
+
         formats();
+        final var defaultFormat = formats.formats().getOrDefault(formats.defaultFormat(), DefaultFormatFactory.createDefaultFormat());
+        ChatFormat.defaultFormat(defaultFormat);
     }
 
     public @NotNull ChannelsHolder channels() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -11,19 +11,19 @@ import java.util.List;
 /**
  * Used to create default objects in the config
  */
-final class DefaultConfigObjects {
+public final class DefaultConfigObjects {
 
-    static @NotNull ChatChannel createDefaultChannel() {
-        return ChatChannel.of(
+    public static @NotNull ChatChannel createDefaultChannel() {
+        return new ChatChannel("default",
                 "", "global", "<gray>[<blue>Global<gray>]", Collections.emptyList());
     }
 
-    static @NotNull ChatChannel createStaffChannel() {
-        return ChatChannel.of("@", "staffchat", "<gray>[<green>Staff<gray>]", Collections.emptyList());
+    public static @NotNull ChatChannel createStaffChannel() {
+        return new ChatChannel("staff", "@", "staffchat", "<gray>[<green>Staff<gray>]", Collections.emptyList());
     }
 
-    static @NotNull ChatFormat createDefaultFormat() {
-        return ChatFormat.of(2,
+    public static @NotNull ChatFormat createDefaultFormat() {
+        return new ChatFormat("default", 2,
                 List.of(
                         "%chatchat_channel_prefix% ",
                         "<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] ",
@@ -32,8 +32,8 @@ final class DefaultConfigObjects {
                         "<white><message>"));
     }
 
-    static @NotNull ChatFormat createOtherFormat() {
-        return ChatFormat.of(1,
+    public static @NotNull ChatFormat createOtherFormat() {
+        return new ChatFormat("other", 1,
                 List.of(
                         "%chatchat_channel_prefix% ",
                         "<hover:show_text:\"Prefix: %vault_group%\"><gray>[<gradient:#40c9ff:#e81cff>ChatChat<gray>] ",
@@ -42,11 +42,11 @@ final class DefaultConfigObjects {
                         "<white><message>"));
     }
 
-    static @NotNull PMFormat createPrivateMessageSenderFormat() {
-        return PMFormat.of(List.of("<gray>you <color:#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
+    public static @NotNull PMFormat createPrivateMessageSenderFormat() {
+        return new PMFormat("sender", List.of("<gray>you <color:#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
     }
 
-    static @NotNull PMFormat createPrivateMessageRecipientFormat() {
-        return PMFormat.of(List.of("<gray>%player_name% <#40c9ff>-> <gray>you <#e81cff>» <white><message>"));
+    public static @NotNull PMFormat createPrivateMessageRecipientFormat() {
+        return new PMFormat("recipient", List.of("<gray>%player_name% <#40c9ff>-> <gray>you <#e81cff>» <white><message>"));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/ChannelsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/ChannelsHolder.java
@@ -1,6 +1,7 @@
-package at.helpch.chatchat.config;
+package at.helpch.chatchat.config.holders;
 
 import at.helpch.chatchat.channel.ChatChannel;
+import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/FormatsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/FormatsHolder.java
@@ -1,5 +1,6 @@
-package at.helpch.chatchat.config;
+package at.helpch.chatchat.config.holders;
 
+import at.helpch.chatchat.config.DefaultConfigObjects;
 import at.helpch.chatchat.format.ChatFormat;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
@@ -1,5 +1,6 @@
-package at.helpch.chatchat.config;
+package at.helpch.chatchat.config.holders;
 
+import at.helpch.chatchat.config.DefaultConfigObjects;
 import at.helpch.chatchat.format.PMFormat;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
@@ -1,0 +1,56 @@
+package at.helpch.chatchat.config.mapper;
+
+import at.helpch.chatchat.channel.ChatChannel;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+
+public final class ChannelMapper implements TypeSerializer<ChatChannel> {
+
+    private static final String TOGGLE_COMMAND = "toggle-command";
+    private static final String MESSAGE_PREFIX = "message-prefix";
+    private static final String CHANNEL_PREFIX = "channel-prefix";
+
+    private ConfigurationNode nonVirtualNode(final ConfigurationNode source, final Object... path) throws SerializationException {
+        if (!source.hasChild(path)) {
+            throw new SerializationException("Required field " + Arrays.toString(path) + " was not present in node");
+        }
+        return source.node(path);
+    }
+
+    @Override
+    public ChatChannel deserialize(Type type, ConfigurationNode node) throws SerializationException {
+        final var keyNode = node.key();
+        if (keyNode == null) {
+            throw new SerializationException("A config key cannot be null!");
+        }
+        final var key = keyNode.toString();
+
+        final var commandName = nonVirtualNode(node, TOGGLE_COMMAND).getString();
+        if (commandName == null) {
+            throw new SerializationException("Command name for " + key + " cannot be null!");
+        }
+
+        final var messagePrefix = nonVirtualNode(node, MESSAGE_PREFIX).getString("");
+        final var channelPrefix = nonVirtualNode(node, CHANNEL_PREFIX).getString("");
+
+        return new ChatChannel(key, messagePrefix, commandName, channelPrefix, Collections.emptyList());
+    }
+
+    @Override
+    public void serialize(Type type, @Nullable ChatChannel channel, ConfigurationNode target) throws SerializationException {
+        if (channel == null) {
+            target.raw(null);
+            return;
+        }
+
+        target.node(TOGGLE_COMMAND).set(channel.commandName());
+        target.node(MESSAGE_PREFIX).set(channel.messagePrefix());
+        target.node(CHANNEL_PREFIX).set(channel.channelPrefix());
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChatFormatMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChatFormatMapper.java
@@ -1,0 +1,52 @@
+package at.helpch.chatchat.config.mapper;
+
+import at.helpch.chatchat.format.ChatFormat;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public final class ChatFormatMapper implements TypeSerializer<ChatFormat> {
+
+    private static final String PRIORITY = "priority";
+    private static final String PARTS = "parts";
+
+    private ConfigurationNode nonVirtualNode(final ConfigurationNode source, final Object... path) throws SerializationException {
+        if (!source.hasChild(path)) {
+            throw new SerializationException("Required field " + Arrays.toString(path) + " was not present in node");
+        }
+        return source.node(path);
+    }
+
+    @Override
+    public ChatFormat deserialize(Type type, ConfigurationNode node) throws SerializationException {
+        final var keyNode = node.key();
+        if (keyNode == null) {
+            throw new SerializationException("A config key cannot be null!");
+        }
+        final var key = keyNode.toString();
+
+        final var priority = nonVirtualNode(node, PRIORITY).getInt();
+
+        final var parts = nonVirtualNode(node, PARTS).getList(String.class);
+        if (parts == null) {
+            throw new SerializationException("Parts list of node: " + key + " cannot be null!");
+        }
+
+        return new ChatFormat(key, priority, parts);
+    }
+
+    @Override
+    public void serialize(Type type, @Nullable ChatFormat format, ConfigurationNode target) throws SerializationException {
+        if (format == null) {
+            target.raw(null);
+            return;
+        }
+
+        target.node(PRIORITY).set(format.priority());
+        target.node(PARTS).set(format.parts());
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/PMFormatMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/PMFormatMapper.java
@@ -1,0 +1,48 @@
+package at.helpch.chatchat.config.mapper;
+
+import at.helpch.chatchat.format.PMFormat;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+public final class PMFormatMapper implements TypeSerializer<PMFormat> {
+
+    private static final String PARTS = "parts";
+
+    private ConfigurationNode nonVirtualNode(final ConfigurationNode source, final Object... path) throws SerializationException {
+        if (!source.hasChild(path)) {
+            throw new SerializationException("Required field " + Arrays.toString(path) + " was not present in node");
+        }
+        return source.node(path);
+    }
+
+    @Override
+    public PMFormat deserialize(Type type, ConfigurationNode node) throws SerializationException {
+        final var keyNode = node.key();
+        if (keyNode == null) {
+            throw new SerializationException("A config key cannot be null!");
+        }
+        final var key = keyNode.toString();
+
+        final var parts = nonVirtualNode(node, PARTS).getList(String.class);
+        if (parts == null) {
+            throw new SerializationException("Parts list of node: " + key + " cannot be null!");
+        }
+
+        return new PMFormat(key, parts);
+    }
+
+    @Override
+    public void serialize(Type type, @Nullable PMFormat format, ConfigurationNode target) throws SerializationException {
+        if (format == null) {
+            target.raw(null);
+            return;
+        }
+
+        target.node(PARTS).set(format.parts());
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -4,20 +4,18 @@ import at.helpch.chatchat.api.Format;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-import java.util.Collections;
 import java.util.List;
 
 @ConfigSerializable
 public final class ChatFormat implements Format {
 
     public static transient final ChatFormat DEFAULT_FORMAT = DefaultFormatFactory.createDefaultFormat();
-    private int priority = Integer.MAX_VALUE;
-    private List<String> parts = Collections.emptyList();
+    private final String name;
+    private final int priority;
+    private final List<String> parts;
 
-    // constructor for Configurate
-    public ChatFormat() {}
-
-    private ChatFormat(final int priority, @NotNull final List<String> parts) {
+    public ChatFormat(@NotNull final String name, final int priority, @NotNull final List<String> parts) {
+        this.name = name;
         this.priority = priority;
         this.parts = parts;
     }
@@ -29,7 +27,7 @@ public final class ChatFormat implements Format {
 
     @Override
     public @NotNull ChatFormat priority(final int priority) {
-        return of(priority, parts);
+        return new ChatFormat(name, priority, parts);
     }
 
     @Override
@@ -39,17 +37,22 @@ public final class ChatFormat implements Format {
 
     @Override
     public @NotNull ChatFormat parts(@NotNull final List<String> parts) {
-        return of(priority, parts);
+        return new ChatFormat(name, priority, parts);
     }
 
-    public static @NotNull ChatFormat of(final int priority, @NotNull final List<String> parts) {
-        return new ChatFormat(priority, parts);
+    public @NotNull String name() {
+        return name;
+    }
+
+    public @NotNull ChatFormat name(@NotNull final String name) {
+        return new ChatFormat(name, priority, parts);
     }
 
     @Override
     public String toString() {
         return "ChatFormat{" +
-                "priority=" + priority +
+                "name=" + name +
+                ", priority=" + priority +
                 ", parts=" + parts +
                 '}';
     }

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -9,7 +9,7 @@ import java.util.List;
 @ConfigSerializable
 public final class ChatFormat implements Format {
 
-    public static transient final ChatFormat DEFAULT_FORMAT = DefaultFormatFactory.createDefaultFormat();
+    private static ChatFormat defaultFormat = DefaultFormatFactory.createDefaultFormat();
     private final String name;
     private final int priority;
     private final List<String> parts;
@@ -46,6 +46,14 @@ public final class ChatFormat implements Format {
 
     public @NotNull ChatFormat name(@NotNull final String name) {
         return new ChatFormat(name, priority, parts);
+    }
+
+    public static @NotNull ChatFormat defaultFormat() {
+        return defaultFormat;
+    }
+
+    public static void defaultFormat(@NotNull final ChatFormat format) {
+        defaultFormat = format;
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -12,7 +12,7 @@ final class DefaultFormatFactory {
     B - The default-format config option isn't set correctly
      */
     static @NotNull ChatFormat createDefaultFormat() {
-        return ChatFormat.of(1,
+        return new ChatFormat("default", 1,
                 List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] %player_name% » %message%"));
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -4,14 +4,14 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-final class DefaultFormatFactory {
+public final class DefaultFormatFactory {
 
     /*
     This is only used as an internal format to send when a user:
     A - doesn't have any format permissions
     B - The default-format config option isn't set correctly
      */
-    static @NotNull ChatFormat createDefaultFormat() {
+    public static @NotNull ChatFormat createDefaultFormat() {
         return new ChatFormat("default", 1,
                 List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] %player_name% » %message%"));
     }

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -4,19 +4,27 @@ import at.helpch.chatchat.api.Format;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
-import java.util.Collections;
 import java.util.List;
 
 @ConfigSerializable
 public final class PMFormat implements Format {
 
-    private List<String> parts = Collections.emptyList();
+    private final String name;
+    private final List<String> parts;
 
-    // constructor for Configurate
-    public PMFormat() {}
-
-    private PMFormat(@NotNull final List<String> parts) {
+    public PMFormat(@NotNull final String name, @NotNull final List<String> parts) {
+        this.name = name;
         this.parts = parts;
+    }
+
+    @Override
+    public @NotNull String name() {
+        return name;
+    }
+
+    @Override
+    public @NotNull Format name(@NotNull String name) {
+        return new PMFormat(name, parts);
     }
 
     @Override
@@ -36,17 +44,14 @@ public final class PMFormat implements Format {
 
     @Override
     public @NotNull PMFormat parts(@NotNull final List<String> parts) {
-        return of(parts);
-    }
-
-    public static @NotNull PMFormat of(@NotNull final List<String> parts) {
-        return new PMFormat(parts);
+        return new PMFormat(name, parts);
     }
 
     @Override
     public String toString() {
         return "PMFormat{" +
-                "priority=" + priority() +
+                "name=" + name +
+                ", priority=" + priority() +
                 ", parts=" + parts +
                 '}';
     }

--- a/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
+++ b/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
@@ -70,8 +70,7 @@ public final class ChatPlaceholders extends PlaceholderExpansion {
         if (params[0].equals("channel")) {
             switch (params[1]) {
                 case "name":
-                    // I know unchecked cast etc, but this will al be fixed or at least Kaliber said he'll make finding channel names easier.
-                    return ChannelUtils.findChannelName(plugin.configManager().channels().channels(), (ChatChannel) user.channel()).orElse("");
+                    return user.channel().name();
                 case "prefix":
                     return user.channel().channelPrefix();
             }

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.util.ChannelUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -47,10 +48,18 @@ public final class ChatUser implements User {
     }
 
     public boolean canSee(@NotNull final Channel channel) {
+        if (channel.equals(ChatChannel.defaultChannel())) {
+            return true;
+        }
+
         return player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + channel.name());
     }
 
     public boolean canUse(@NotNull final Channel channel) {
+        if (channel.equals(ChatChannel.defaultChannel())) {
+            return true;
+        }
+
         return player().hasPermission(ChannelUtils.USE_CHANNEL_PERMISSION + channel.name());
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
@@ -47,11 +47,11 @@ public final class ChatUser implements User {
     }
 
     public boolean canSee(@NotNull final Channel channel) {
-        return player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + channel.commandName());
+        return player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + channel.name());
     }
 
     public boolean canUse(@NotNull final Channel channel) {
-        return player().hasPermission(ChannelUtils.USE_CHANNEL_PERMISSION + channel.commandName());
+        return player().hasPermission(ChannelUtils.USE_CHANNEL_PERMISSION + channel.name());
     }
 
     public @NotNull Optional<User> lastMessagedUser() {

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -23,7 +23,7 @@ public final class ChannelUtils {
             @NotNull final Map<String, ChatChannel> channels,
             @NotNull final String defaultChannel) {
         final var channel = channels.get(defaultChannel);
-        return Objects.requireNonNullElseGet(channel, DefaultConfigObjects::createDefaultChannel);
+        return Objects.requireNonNullElseGet(channel, ChatChannel::defaultChannel);
     }
 
     public static @NotNull Optional<ChatChannel> findChannelByPrefix(

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.util;
 
 import at.helpch.chatchat.channel.ChatChannel;
+import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public final class ChannelUtils {
             @NotNull final Map<String, ChatChannel> channels,
             @NotNull final String defaultChannel) {
         final var channel = channels.get(defaultChannel);
-        return Objects.requireNonNullElseGet(channel, ChatChannel::new);
+        return Objects.requireNonNullElseGet(channel, DefaultConfigObjects::createDefaultChannel);
     }
 
     public static @NotNull Optional<ChatChannel> findChannelByPrefix(

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -34,14 +34,4 @@ public final class ChannelUtils {
                 .filter(channel -> input.startsWith(channel.messagePrefix()))
                 .findFirst();
     }
-
-    public static @NotNull Optional<String> findChannelName(
-        @NotNull final Map<String, ChatChannel> channels,
-        @NotNull final ChatChannel channel
-    ) {
-        return channels.entrySet().stream()
-            .filter(entry -> entry.getValue().equals(channel))
-            .map(Map.Entry::getKey)
-            .findFirst();
-    }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.util;
 
 import at.helpch.chatchat.api.Format;
-import at.helpch.chatchat.config.FormatsHolder;
+import at.helpch.chatchat.config.holders.FormatsHolder;
 import at.helpch.chatchat.format.ChatFormat;
 import java.util.List;
 import java.util.regex.Pattern;

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -49,9 +49,8 @@ public final class FormatUtils {
     public static @NotNull Optional<ChatFormat> findPermissionFormat(
             @NotNull final Player player,
             @NotNull final Map<String, ChatFormat> formats) {
-        return formats.entrySet().stream()
-                .filter(entry -> player.hasPermission(FORMAT_PERMISSION + entry.getKey()))
-                .map(Map.Entry::getValue)
+        return formats.values().stream()
+                .filter(value -> player.hasPermission(FORMAT_PERMISSION + value.name()))
                 .min(Comparator.comparingInt(ChatFormat::priority)); // lower number = higher priority
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -58,9 +58,8 @@ public final class FormatUtils {
             @NotNull final Player player,
             @NotNull final FormatsHolder formats) {
         final var formatOptional = findPermissionFormat(player, formats.formats());
-        final var defaultFormat = formats.formats().getOrDefault(formats.defaultFormat(), ChatFormat.DEFAULT_FORMAT);
 
-        return formatOptional.orElse(defaultFormat);
+        return formatOptional.orElse(ChatFormat.defaultFormat());
     }
 
     public static @NotNull Component parseFormat(


### PR DESCRIPTION
The config objects now have custom serializers. This means that we no longer require a 0-args constructor and allows for the objects to be fully immutable. Not only this, but their config key is now stored inside of Format#name() or Channel#name() for easy access.

The default channel/format is now set inside of a static variable and is updated on reload. These no longer require a permission too.