### PR TITLE
Added a PMSendEvent and some more.

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -24,12 +24,13 @@ public class ChatChatEvent extends Event implements Cancellable {
     }
 
     public ChatChatEvent(
-            final boolean async,
-            @NotNull final Player player,
-            @NotNull final Audience recipients,
-            @NotNull final Format format,
-            @NotNull final String message,
-            @NotNull final Channel channel) {
+        final boolean async,
+        @NotNull final Player player,
+        @NotNull final Audience recipients,
+        @NotNull final Format format,
+        @NotNull final String message,
+        @NotNull final Channel channel
+    ) {
         super(async);
         this.player = player;
         this.recipients = recipients;
@@ -48,7 +49,7 @@ public class ChatChatEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean cancelled) {
+    public void setCancelled(final boolean cancelled) {
         this.cancelled = cancelled;
     }
 
@@ -60,7 +61,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         return recipients;
     }
 
-    public void recipients(Audience recipients) {
+    public void recipients(@NotNull final Audience recipients) {
         this.recipients = recipients;
     }
 
@@ -68,7 +69,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         return format;
     }
 
-    public void format(Format format) {
+    public void format(@NotNull final Format format) {
         this.format = format;
     }
 
@@ -76,7 +77,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         return message;
     }
 
-    public void message(String message) {
+    public void message(@NotNull final String message) {
         this.message = message;
     }
 }

--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -19,6 +19,7 @@ public class ChatChatEvent extends Event implements Cancellable {
     private @NotNull Audience recipients;
     private @NotNull Format format;
     private @NotNull Component message;
+    private @NotNull final Channel channel;
 
     public static HandlerList getHandlerList() {
         return HANDLERS;
@@ -37,6 +38,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         this.recipients = recipients;
         this.format = format;
         this.message = message;
+        this.channel = channel;
     }
 
     @Override
@@ -80,5 +82,9 @@ public class ChatChatEvent extends Event implements Cancellable {
 
     public void message(@NotNull final Component message) {
         this.message = message;
+    }
+
+    public Channel channel() {
+        return channel;
     }
 }

--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -3,6 +3,7 @@ package at.helpch.chatchat.api.event;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.Format;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -17,7 +18,7 @@ public class ChatChatEvent extends Event implements Cancellable {
     private @NotNull final Player player;
     private @NotNull Audience recipients;
     private @NotNull Format format;
-    private @NotNull String message;
+    private @NotNull Component message;
 
     public static HandlerList getHandlerList() {
         return HANDLERS;
@@ -28,7 +29,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         @NotNull final Player player,
         @NotNull final Audience recipients,
         @NotNull final Format format,
-        @NotNull final String message,
+        @NotNull final Component message,
         @NotNull final Channel channel
     ) {
         super(async);
@@ -73,11 +74,11 @@ public class ChatChatEvent extends Event implements Cancellable {
         this.format = format;
     }
 
-    public String message() {
+    public Component message() {
         return message;
     }
 
-    public void message(@NotNull final String message) {
+    public void message(@NotNull final Component message) {
         this.message = message;
     }
 }

--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -60,7 +60,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         return player;
     }
 
-    public Audience recipients() {
+    public @NotNull Audience recipients() {
         return recipients;
     }
 
@@ -68,7 +68,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         this.recipients = recipients;
     }
 
-    public Format format() {
+    public @NotNull Format format() {
         return format;
     }
 
@@ -76,7 +76,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         this.format = format;
     }
 
-    public Component message() {
+    public @NotNull Component message() {
         return message;
     }
 
@@ -84,7 +84,7 @@ public class ChatChatEvent extends Event implements Cancellable {
         this.message = message;
     }
 
-    public Channel channel() {
+    public @NotNull Channel channel() {
         return channel;
     }
 }

--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -1,0 +1,104 @@
+package at.helpch.chatchat.api.event;
+
+import at.helpch.chatchat.api.Format;
+import java.util.Optional;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class PMSendEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private boolean cancelled = false;
+
+    private @NotNull Optional<Component> cancelReason = Optional.of(
+        Component.text("Could not send your message.", NamedTextColor.RED)
+    );
+
+    private @NotNull final Player sender;
+    private @NotNull final Player recipient;
+    private @NotNull Format senderFormat;
+    private @NotNull Format recipientFormat;
+    private @NotNull Component message;
+    private final boolean reply;
+
+    public PMSendEvent(
+        @NotNull final Player sender,
+        @NotNull final Player recipient,
+        @NotNull final Format senderFormat,
+        @NotNull final Format recipientFormat,
+        @NotNull final Component message,
+        final boolean reply
+    ) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.senderFormat = senderFormat;
+        this.recipientFormat = recipientFormat;
+        this.message = message;
+        this.reply = reply;
+    }
+
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(final boolean cancel) {
+        cancelled = cancel;
+    }
+
+    public Player sender() {
+        return sender;
+    }
+
+    public Player recipient() {
+        return recipient;
+    }
+
+    public Format senderFormat() {
+        return senderFormat;
+    }
+
+    public void senderFormat(@NotNull final Format format) {
+        this.senderFormat = format;
+    }
+
+    public Format recipientFormat() {
+        return recipientFormat;
+    }
+
+    public void recipientFormat(@NotNull final Format format) {
+        this.recipientFormat = format;
+    }
+
+    public Component message() {
+        return message;
+    }
+
+    public void message(@NotNull final Component message) {
+        this.message = message;
+    }
+
+    public boolean reply() {
+        return reply;
+    }
+
+    public Optional<Component> cancelReason() {
+        return cancelReason;
+    }
+
+    public void cancelReason(@NotNull final Optional<Component> reason) {
+        this.cancelReason = reason;
+    }
+}

--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -15,10 +15,6 @@ public class PMSendEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS = new HandlerList();
     private boolean cancelled = false;
 
-    private @NotNull Optional<Component> cancelReason = Optional.of(
-        Component.text("Could not send your message.", NamedTextColor.RED)
-    );
-
     private @NotNull final Player sender;
     private @NotNull final Player recipient;
     private @NotNull Format senderFormat;
@@ -92,13 +88,5 @@ public class PMSendEvent extends Event implements Cancellable {
 
     public boolean reply() {
         return reply;
-    }
-
-    public Optional<Component> cancelReason() {
-        return cancelReason;
-    }
-
-    public void cancelReason(@NotNull final Optional<Component> reason) {
-        this.cancelReason = reason;
     }
 }

--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -58,15 +58,15 @@ public class PMSendEvent extends Event implements Cancellable {
         cancelled = cancel;
     }
 
-    public Player sender() {
+    public @NotNull Player sender() {
         return sender;
     }
 
-    public Player recipient() {
+    public @NotNull Player recipient() {
         return recipient;
     }
 
-    public Format senderFormat() {
+    public @NotNull Format senderFormat() {
         return senderFormat;
     }
 
@@ -74,7 +74,7 @@ public class PMSendEvent extends Event implements Cancellable {
         this.senderFormat = format;
     }
 
-    public Format recipientFormat() {
+    public @NotNull Format recipientFormat() {
         return recipientFormat;
     }
 
@@ -82,7 +82,7 @@ public class PMSendEvent extends Event implements Cancellable {
         this.recipientFormat = format;
     }
 
-    public Component message() {
+    public @NotNull Component message() {
         return message;
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -60,9 +60,6 @@ public final class ReplyCommand extends BaseCommand {
         plugin.getServer().getPluginManager().callEvent(pmSendEvent);
 
         if (pmSendEvent.isCancelled()) {
-            if (pmSendEvent.cancelReason().isPresent()) {
-                plugin.audiences().player(sender).sendMessage(pmSendEvent.cancelReason().get());
-            }
             return;
         }
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -50,9 +50,6 @@ public final class WhisperCommand extends BaseCommand {
         plugin.getServer().getPluginManager().callEvent(pmSendEvent);
 
         if (pmSendEvent.isCancelled()) {
-            if (pmSendEvent.cancelReason().isPresent()) {
-                plugin.audiences().player(sender).sendMessage(pmSendEvent.cancelReason().get());
-            }
             return;
         }
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -1,13 +1,13 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.event.PMSendEvent;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.Default;
 import dev.triumphteam.cmd.core.annotation.Join;
-import dev.triumphteam.cmd.core.annotation.Suggestion;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -38,17 +38,35 @@ public final class WhisperCommand extends BaseCommand {
         final var senderFormat = settingsConfig.getSenderFormat();
         final var recipientFormat = settingsConfig.getRecipientFormat();
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
-            senderFormat,
+        final var pmSendEvent = new PMSendEvent(
             sender,
             recipient,
-            Component.text(message)
+            senderFormat,
+            recipientFormat,
+            Component.text(message),
+            false
+        );
+
+        plugin.getServer().getPluginManager().callEvent(pmSendEvent);
+
+        if (pmSendEvent.isCancelled()) {
+            if (pmSendEvent.cancelReason().isPresent()) {
+                plugin.audiences().player(sender).sendMessage(pmSendEvent.cancelReason().get());
+            }
+            return;
+        }
+
+        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
+            pmSendEvent.senderFormat(),
+            sender,
+            recipient,
+            pmSendEvent.message()
         ));
         plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(
-            recipientFormat,
+            pmSendEvent.recipientFormat(),
             sender,
             recipient,
-            Component.text(message)
+            pmSendEvent.message()
         ));
 
         final var usersHolder = plugin.usersHolder();

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -54,7 +54,7 @@ public final class ChatListener implements Listener {
                 event.getPlayer(),
                 audience,
                 format,
-                message,
+                Component.text(message),
                 channel
         );
 
@@ -67,7 +67,7 @@ public final class ChatListener implements Listener {
         chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
             chatEvent.format(),
             player,
-            Component.text(chatEvent.message())
+            chatEvent.message()
         ));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -82,6 +82,7 @@ public final class FormatUtils {
         @NotNull final ComponentLike message) {
         return format.parts().stream()
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
+            .map(part -> PlaceholderAPI.setRelationalPlaceholders(player, recipient, part))
             .map(part -> replaceRecipientPlaceholder(recipient, part))
             .map(part -> FormatUtils.parseToMiniMessage(part,
                 Placeholder.component("message", !player.hasPermission(URL_PERMISSION)


### PR DESCRIPTION
- Added a PMSendEvent, fired when a private message is sent. (there is a way to tell if it was a reply or just a normal PM as well)
- Made it so the message in ChatChatEvent is Component. This way we can promote usage of Components over Strings to other developers as well.
- Added some missing @NotNull annotations and some final keywords.
- Added getter for channel in ChatChatEvent
- Added relational PAPI placeholder support. Currently it only works in PMs.