### PR TITLE
Implement Audience, Commands now use the custom User object

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/Channel.java
+++ b/api/src/main/java/at/helpch/chatchat/api/Channel.java
@@ -1,10 +1,9 @@
 package at.helpch.chatchat.api;
 
+import net.kyori.adventure.audience.ForwardingAudience;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
-public interface Channel {
+public interface Channel extends ForwardingAudience {
 
     @NotNull String name();
 
@@ -12,7 +11,8 @@ public interface Channel {
 
     @NotNull String channelPrefix();
 
-    @NotNull List<User> audience();
-
     @NotNull String commandName();
+
+    @Override
+    @NotNull Iterable<User> audiences();
 }

--- a/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
+++ b/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
@@ -1,0 +1,16 @@
+package at.helpch.chatchat.api;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+public interface ChatUser extends User {
+
+    @NotNull Player player();
+
+    @NotNull Optional<ChatUser> lastMessagedUser();
+
+    void lastMessagedUser(@Nullable final ChatUser user);
+}

--- a/api/src/main/java/at/helpch/chatchat/api/User.java
+++ b/api/src/main/java/at/helpch/chatchat/api/User.java
@@ -2,10 +2,8 @@ package at.helpch.chatchat.api;
 
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identified;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface User extends ForwardingAudience.Single, Identified {
@@ -24,9 +22,4 @@ public interface User extends ForwardingAudience.Single, Identified {
 
     boolean canUse(@NotNull final Channel channel);
 
-    @NotNull Optional<User> lastMessagedUser();
-
-    void lastMessagedUser(@NotNull final User user);
-
-    @NotNull Player player();
 }

--- a/api/src/main/java/at/helpch/chatchat/api/User.java
+++ b/api/src/main/java/at/helpch/chatchat/api/User.java
@@ -1,12 +1,14 @@
 package at.helpch.chatchat.api;
 
+import net.kyori.adventure.audience.ForwardingAudience;
+import net.kyori.adventure.identity.Identified;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface User {
+public interface User extends ForwardingAudience.Single, Identified {
 
     @NotNull Channel channel();
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -35,7 +35,14 @@ bukkit {
 tasks {
     withType<ShadowJar> {
         minimize()
-        relocate("net.kyori", "at.helpch.chatchat.libs.adventure")
+
+        listOf("net.kyori",
+            "dev.triumphteam",
+            "org.spongepowered",
+            "io.leangen",
+            "org.yaml"
+        ).forEach { relocate(it, "at.helpch.chatchat.libs.$it") }
+
         archiveFileName.set("ChatChat-${project.version}.jar")
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -13,15 +13,11 @@ import at.helpch.chatchat.placeholder.ChatPlaceholders;
 import at.helpch.chatchat.user.UsersHolder;
 import dev.triumphteam.annotations.BukkitMain;
 import dev.triumphteam.cmd.bukkit.BukkitCommandManager;
-import dev.triumphteam.cmd.core.suggestion.SuggestionKey;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @BukkitMain
 public final class ChatChatPlugin extends JavaPlugin {

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat;
 
 import at.helpch.chatchat.api.Channel;
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.command.MainCommand;
 import at.helpch.chatchat.command.ReloadCommand;
 import at.helpch.chatchat.command.ReplyCommand;
@@ -10,7 +11,6 @@ import at.helpch.chatchat.config.ConfigManager;
 import at.helpch.chatchat.listener.ChatListener;
 import at.helpch.chatchat.listener.PlayerListener;
 import at.helpch.chatchat.placeholder.ChatPlaceholders;
-import at.helpch.chatchat.user.ChatUser;
 import at.helpch.chatchat.user.UserSenderValidator;
 import at.helpch.chatchat.user.UsersHolder;
 import dev.triumphteam.annotations.BukkitMain;

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -52,13 +52,13 @@ public final class ChatChannel implements Channel {
     }
 
     @Override
-    public @NotNull List<User> audience() {
-        return audience;
+    public @NotNull String commandName() {
+        return toggleCommand;
     }
 
     @Override
-    public @NotNull String commandName() {
-        return toggleCommand;
+    public @NotNull Iterable<User> audiences() {
+        return audience;
     }
 
     public static @NotNull ChatChannel defaultChannel() {

--- a/plugin/src/main/java/at/helpch/chatchat/command/MainCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/MainCommand.java
@@ -1,12 +1,12 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.User;
 import dev.triumphteam.cmd.core.annotation.Default;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
-import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
 import static net.kyori.adventure.text.Component.text;
@@ -20,7 +20,7 @@ public final class MainCommand extends ChatChatCommand {
     }
 
     @Default
-    public void defaultCommand(final CommandSender sender) {
+    public void defaultCommand(final User sender) {
         var text = text("A Chat Plugin ", NamedTextColor.AQUA)
                 .append(text("by ", NamedTextColor.GRAY)
                 .append(text("Help", TextColor.fromCSSHexString("#3dbbe4"))
@@ -30,6 +30,6 @@ public final class MainCommand extends ChatChatCommand {
                 .append(text("Version: ", NamedTextColor.GRAY))
                 .append(text(plugin.getDescription().getVersion(), NamedTextColor.AQUA));
 
-        plugin.audiences().sender(sender).sendMessage(text);
+        sender.sendMessage(text);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -1,11 +1,11 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.User;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.annotation.SubCommand;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
 public final class ReloadCommand extends ChatChatCommand {
@@ -19,13 +19,12 @@ public final class ReloadCommand extends ChatChatCommand {
 
     @SubCommand("reload")
     @Permission(ADMIN_PERMISSION)
-    public void reloadCommand(final CommandSender sender) {
+    public void reloadCommand(final User sender) {
         plugin.configManager().reload();
 
         var formatsConfig = plugin.configManager().formats();
 
         int formats = formatsConfig.formats().size();
-        plugin.audiences().sender(sender)
-                .sendMessage(Component.text(formats + " " + (formats == 1 ? "format" : "formats") + " loaded!", NamedTextColor.GREEN));
+        sender.sendMessage(Component.text(formats + " " + (formats == 1 ? "format" : "formats") + " loaded!", NamedTextColor.GREEN));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -1,8 +1,8 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.PMSendEvent;
-import at.helpch.chatchat.user.ChatUser;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.event.PMSendEvent;
+import at.helpch.chatchat.user.ChatUser;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
@@ -10,7 +11,6 @@ import dev.triumphteam.cmd.core.annotation.Default;
 import dev.triumphteam.cmd.core.annotation.Join;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @Command(value = "reply", alias = "r")
@@ -25,21 +25,18 @@ public final class ReplyCommand extends BaseCommand {
 
     @Default
     @Permission(MESSAGE_PERMISSION)
-    public void reply(final Player sender, @Join final String message) {
-        final var user = plugin.usersHolder().getUser(sender);
+    public void reply(final ChatUser user, @Join final String message) {
         final var lastMessaged = user.lastMessagedUser();
 
         if (lastMessaged.isEmpty()) {
-            plugin.audiences().player(sender).sendMessage(
-                    Component.text("You have no one to reply to!", NamedTextColor.RED));
+            user.sendMessage(Component.text("You have no one to reply to!", NamedTextColor.RED));
             return;
         }
 
         final var recipientUser = lastMessaged.get();
         final var recipient = recipientUser.player();
         if (!recipient.isOnline()) {
-            plugin.audiences().player(sender).sendMessage(
-                    Component.text("This player is no longer online", NamedTextColor.RED));
+            user.sendMessage(Component.text("This player is no longer online", NamedTextColor.RED));
             return;
         }
 
@@ -49,7 +46,7 @@ public final class ReplyCommand extends BaseCommand {
         final var recipientFormat = settingsConfig.getRecipientFormat();
 
         final var pmSendEvent = new PMSendEvent(
-            sender,
+            user.player(),
             recipient,
             senderFormat,
             recipientFormat,
@@ -63,15 +60,15 @@ public final class ReplyCommand extends BaseCommand {
             return;
         }
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
+        user.sendMessage(FormatUtils.parseFormat(
             pmSendEvent.senderFormat(),
-            sender,
+            user.player(),
             recipient,
             pmSendEvent.message()
         ));
-        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(
+        recipientUser.sendMessage(FormatUtils.parseFormat(
             pmSendEvent.recipientFormat(),
-            sender,
+            user.player(),
             recipient,
             pmSendEvent.message()
         ));

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -1,11 +1,11 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.user.ChatUser;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Default;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 public final class SwitchChannelCommand extends BaseCommand {
@@ -20,8 +20,7 @@ public final class SwitchChannelCommand extends BaseCommand {
     }
 
     @Default
-    public void switchChannel(final Player player) {
-        final var user = plugin.usersHolder().getUser(player.getUniqueId());
+    public void switchChannel(final ChatUser user) {
 
         final var channels = plugin.configManager().channels().channels();
         final var channel = channels.values()
@@ -30,14 +29,12 @@ public final class SwitchChannelCommand extends BaseCommand {
                 .findAny()
                 .get(); // this should probably only ever throw if the person has changed command names without restarting
 
-        final var audiencePlayer = plugin.audiences().player(player);
-
         if (!user.canUse(channel)) {
-            audiencePlayer.sendMessage(Component.text("You don't have permission to use this channel!", NamedTextColor.RED));
+            user.sendMessage(Component.text("You don't have permission to use this channel!", NamedTextColor.RED));
             return;
         }
 
         user.channel(channel);
-        audiencePlayer.sendMessage(Component.text("You have switched to the " + command + " channel!", NamedTextColor.GREEN));
+        user.sendMessage(Component.text("You have switched to the " + command + " channel!", NamedTextColor.GREEN));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.user.ChatUser;
+import at.helpch.chatchat.api.ChatUser;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Default;
 import net.kyori.adventure.text.Component;

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.event.PMSendEvent;
+import at.helpch.chatchat.user.ChatUser;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
@@ -10,7 +11,6 @@ import dev.triumphteam.cmd.core.annotation.Default;
 import dev.triumphteam.cmd.core.annotation.Join;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 @Command(value = "whisper", alias = {"tell", "w", "msg", "message", "pm"})
@@ -25,11 +25,10 @@ public final class WhisperCommand extends BaseCommand {
 
     @Default
     @Permission(MESSAGE_PERMISSION)
-    public void whisperCommand(final Player sender, final Player recipient, @Join final String message) {
+    public void whisperCommand(final ChatUser user, final ChatUser recipient, @Join final String message) {
 
-        if (sender.equals(recipient)) {
-            plugin.audiences().player(sender).sendMessage(
-                    Component.text("You can't message yourself!", NamedTextColor.RED));
+        if (user.equals(recipient)) {
+            user.sendMessage(Component.text("You can't message yourself!", NamedTextColor.RED));
             return;
         }
 
@@ -39,8 +38,8 @@ public final class WhisperCommand extends BaseCommand {
         final var recipientFormat = settingsConfig.getRecipientFormat();
 
         final var pmSendEvent = new PMSendEvent(
-            sender,
-            recipient,
+            user.player(),
+            recipient.player(),
             senderFormat,
             recipientFormat,
             Component.text(message),
@@ -53,24 +52,20 @@ public final class WhisperCommand extends BaseCommand {
             return;
         }
 
-        plugin.audiences().player(sender).sendMessage(FormatUtils.parseFormat(
+        user.sendMessage(FormatUtils.parseFormat(
             pmSendEvent.senderFormat(),
-            sender,
-            recipient,
+            user.player(),
+            recipient.player(),
             pmSendEvent.message()
         ));
-        plugin.audiences().player(recipient).sendMessage(FormatUtils.parseFormat(
+        recipient.sendMessage(FormatUtils.parseFormat(
             pmSendEvent.recipientFormat(),
-            sender,
-            recipient,
+            user.player(),
+            recipient.player(),
             pmSendEvent.message()
         ));
 
-        final var usersHolder = plugin.usersHolder();
-        final var user = usersHolder.getUser(sender);
-        final var recipientUser = usersHolder.getUser(recipient);
-
-        user.lastMessagedUser(recipientUser);
-        recipientUser.lastMessagedUser(user);
+        user.lastMessagedUser(recipient);
+        recipient.lastMessagedUser(user);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -1,8 +1,9 @@
 package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.PMSendEvent;
-import at.helpch.chatchat.user.ChatUser;
+import at.helpch.chatchat.user.ChatUserImpl;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -45,8 +45,6 @@ public final class ChatListener implements Listener {
         final var audience = plugin.usersHolder().users()
                 .stream()
                 .filter(otherUser -> otherUser.canSee(channel)) // get everyone who can see this channel
-                .map(User::player)
-                .map(plugin.audiences()::player)
                 .collect(Audience.toAudience());
 
         final var chatEvent = new ChatChatEvent(

--- a/plugin/src/main/java/at/helpch/chatchat/listener/PlayerListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/PlayerListener.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.listener;
 
 import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.util.ChannelUtils;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -27,6 +28,15 @@ public final class PlayerListener implements Listener {
 
     @EventHandler
     private void onLeave(final PlayerQuitEvent event) {
+
+        // find everyone who last messaged the person leaving, and remove their reference
+        plugin.usersHolder().users().stream()
+                .filter(user -> user instanceof ChatUser)
+                .map(user -> (ChatUser) user)
+                .filter(user -> user.lastMessagedUser().isPresent())
+                .filter(user -> user.lastMessagedUser().get().player().equals(event.getPlayer()))
+                .forEach(user -> user.lastMessagedUser(null));
+
         plugin.usersHolder().removeUser(event.getPlayer());
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUser.java
@@ -1,5 +1,6 @@
 package at.helpch.chatchat.user;
 
+import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.Format;
 import at.helpch.chatchat.api.User;
@@ -10,6 +11,8 @@ import java.util.UUID;
 
 import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.util.ChannelUtils;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.identity.Identity;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -73,6 +76,16 @@ public final class ChatUser implements User {
 
     public @NotNull Player player() {
         return Objects.requireNonNull(Bukkit.getPlayer(uuid)); // this will never be null
+    }
+
+    @Override
+    public @NotNull Audience audience() {
+        return ChatChatPlugin.audiences().player(uuid);
+    }
+
+    @Override
+    public @NotNull Identity identity() {
+        return Identity.identity(uuid);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.user;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.Format;
 import at.helpch.chatchat.api.User;
 
@@ -16,15 +17,16 @@ import net.kyori.adventure.identity.Identity;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public final class ChatUser implements User {
+public final class ChatUserImpl implements ChatUser {
 
-    public ChatUser(@NotNull final UUID uuid) {
+    public ChatUserImpl(@NotNull final UUID uuid) {
         this.uuid = uuid;
     }
 
     private @NotNull final UUID uuid;
-    private User lastMessaged;
+    private ChatUser lastMessaged;
     private Channel channel;
     private Format format;
 
@@ -38,18 +40,22 @@ public final class ChatUser implements User {
         this.channel = channel;
     }
 
+    @Override
     public @NotNull Format format() {
         return format;
     }
 
+    @Override
     public void format(@NotNull final Format format) {
         this.format = format;
     }
 
+    @Override
     public @NotNull UUID uuid() {
         return uuid;
     }
 
+    @Override
     public boolean canSee(@NotNull final Channel channel) {
         if (channel.equals(ChatChannel.defaultChannel())) {
             return true;
@@ -58,6 +64,7 @@ public final class ChatUser implements User {
         return player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + channel.name());
     }
 
+    @Override
     public boolean canUse(@NotNull final Channel channel) {
         if (channel.equals(ChatChannel.defaultChannel())) {
             return true;
@@ -66,14 +73,17 @@ public final class ChatUser implements User {
         return player().hasPermission(ChannelUtils.USE_CHANNEL_PERMISSION + channel.name());
     }
 
-    public @NotNull Optional<User> lastMessagedUser() {
+    @Override
+    public @NotNull Optional<ChatUser> lastMessagedUser() {
         return Optional.ofNullable(lastMessaged);
     }
 
-    public void lastMessagedUser(@NotNull final User user) {
+    @Override
+    public void lastMessagedUser(@Nullable final ChatUser user) {
         this.lastMessaged = user;
     }
 
+    @Override
     public @NotNull Player player() {
         return Objects.requireNonNull(Bukkit.getPlayer(uuid)); // this will never be null
     }
@@ -90,8 +100,9 @@ public final class ChatUser implements User {
 
     @Override
     public String toString() {
-        return "ChatUser{" +
+        return "ChatUserImpl{" +
                 "uuid=" + uuid +
+                ", lastMessaged=" + lastMessagedUser().map(ChatUser::uuid) +
                 ", channel=" + channel +
                 ", format=" + format +
                 '}';

--- a/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
@@ -1,0 +1,72 @@
+package at.helpch.chatchat.user;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.Channel;
+import at.helpch.chatchat.api.Format;
+import at.helpch.chatchat.api.User;
+import at.helpch.chatchat.channel.ChatChannel;
+import at.helpch.chatchat.format.ChatFormat;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.identity.Identity;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public final class ConsoleUser implements User {
+
+    @Override
+    public @NotNull Channel channel() {
+        return ChatChannel.defaultChannel();
+    }
+
+    @Override
+    public void channel(@NotNull final Channel channel) {}
+
+    @Override
+    public @NotNull Format format() {
+        return ChatFormat.defaultFormat();
+    }
+
+    @Override
+    public void format(@NotNull final Format format) {}
+
+    @Override
+    public @NotNull UUID uuid() {
+        return Identity.nil().uuid();
+    }
+
+    @Override
+    public boolean canSee(@NotNull final Channel channel) {
+        return true;
+    }
+
+    @Override
+    public boolean canUse(@NotNull final Channel channel) {
+        return true;
+    }
+
+    @Override
+    public @NotNull Optional<User> lastMessagedUser() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void lastMessagedUser(@NotNull final User user) {}
+
+    @Override
+    public @NotNull Player player() {
+        return null;
+    }
+
+    @Override
+    public @NotNull Audience audience() {
+        return ChatChatPlugin.audiences().console();
+    }
+
+    @Override
+    public @NotNull Identity identity() {
+        return Identity.nil();
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
@@ -14,6 +14,10 @@ import java.util.UUID;
 
 public final class ConsoleUser implements User {
 
+    public static final ConsoleUser INSTANCE = new ConsoleUser();
+
+    private ConsoleUser() {}
+
     @Override
     public @NotNull Channel channel() {
         return ChatChannel.defaultChannel();

--- a/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
@@ -8,10 +8,8 @@ import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.format.ChatFormat;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public final class ConsoleUser implements User {
@@ -45,19 +43,6 @@ public final class ConsoleUser implements User {
     @Override
     public boolean canUse(@NotNull final Channel channel) {
         return true;
-    }
-
-    @Override
-    public @NotNull Optional<User> lastMessagedUser() {
-        return Optional.empty();
-    }
-
-    @Override
-    public void lastMessagedUser(@NotNull final User user) {}
-
-    @Override
-    public @NotNull Player player() {
-        return null;
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/UserSenderValidator.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/UserSenderValidator.java
@@ -1,0 +1,39 @@
+package at.helpch.chatchat.user;
+
+import at.helpch.chatchat.api.User;
+import dev.triumphteam.cmd.core.SubCommand;
+import dev.triumphteam.cmd.core.message.MessageRegistry;
+import dev.triumphteam.cmd.core.sender.SenderValidator;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public final class UserSenderValidator implements SenderValidator<User> {
+
+    @Override
+    public @NotNull Set<Class<? extends User>> getAllowedSenders() {
+        return Set.of(User.class, ChatUser.class, ConsoleUser.class);
+    }
+
+    @Override
+    public boolean validate(
+            @NotNull final MessageRegistry<User> messageRegistry,
+            @NotNull final SubCommand<User> subCommand,
+            @NotNull final User sender
+    ) {
+        final var senderClass = subCommand.getSenderType();
+
+        if (senderClass == ChatUser.class && !(sender instanceof ChatUser)) {
+            sender.sendMessage(Component.text("Player only."));
+            return false;
+        }
+
+        if (senderClass == ConsoleUser.class && !(sender instanceof ConsoleUser)) {
+            sender.sendMessage(Component.text("ur not console"));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/user/UserSenderValidator.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/UserSenderValidator.java
@@ -1,5 +1,6 @@
 package at.helpch.chatchat.user;
 
+import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.User;
 import dev.triumphteam.cmd.core.SubCommand;
 import dev.triumphteam.cmd.core.message.MessageRegistry;

--- a/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 public final class UsersHolder {
 
-    public static final User CONSOLE = new ConsoleUser();
+    public static final User CONSOLE = ConsoleUser.INSTANCE;
 
     private @NotNull final Map<UUID, User> users = new HashMap<>();
 

--- a/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
@@ -4,18 +4,33 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import at.helpch.chatchat.api.User;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 public final class UsersHolder {
-    private @NotNull final Map<UUID, ChatUser> users = new HashMap<>();
 
-    public @NotNull ChatUser getUser(@NotNull final UUID uuid) {
+    public static final User CONSOLE = new ConsoleUser();
+
+    private @NotNull final Map<UUID, User> users = new HashMap<>();
+
+    public UsersHolder() {
+        users.put(CONSOLE.uuid(), CONSOLE);
+    }
+
+    public @NotNull User getUser(@NotNull final UUID uuid) {
         return users.computeIfAbsent(uuid, ChatUser::new);
     }
 
-    public @NotNull ChatUser getUser(@NotNull final Player player) {
-        return getUser(player.getUniqueId());
+    public @NotNull User getUser(@NotNull final CommandSender user) {
+        if (user instanceof ConsoleCommandSender) {
+            return CONSOLE;
+        }
+
+        return getUser(((Player) user).getUniqueId());
     }
 
     public void removeUser(@NotNull final UUID uuid) {
@@ -26,17 +41,17 @@ public final class UsersHolder {
         removeUser(player.getUniqueId());
     }
 
-    public @NotNull ChatUser addUser(@NotNull final UUID uuid) {
+    public @NotNull User addUser(@NotNull final UUID uuid) {
         ChatUser user = new ChatUser(uuid);
         users.put(uuid, user);
         return user;
     }
 
-    public @NotNull ChatUser addUser(@NotNull final Player player) {
+    public @NotNull User addUser(@NotNull final Player player) {
         return addUser(player.getUniqueId());
     }
 
-    public @NotNull List<ChatUser> users() {
+    public @NotNull List<User> users() {
         return List.copyOf(users.values());
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/UsersHolder.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.user;
 
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -22,7 +22,7 @@ public final class UsersHolder {
     }
 
     public @NotNull User getUser(@NotNull final UUID uuid) {
-        return users.computeIfAbsent(uuid, ChatUser::new);
+        return users.computeIfAbsent(uuid, ChatUserImpl::new);
     }
 
     public @NotNull User getUser(@NotNull final CommandSender user) {
@@ -42,7 +42,7 @@ public final class UsersHolder {
     }
 
     public @NotNull User addUser(@NotNull final UUID uuid) {
-        ChatUser user = new ChatUser(uuid);
+        final var user = new ChatUserImpl(uuid);
         users.put(uuid, user);
         return user;
     }
@@ -51,7 +51,7 @@ public final class UsersHolder {
         return addUser(player.getUniqueId());
     }
 
-    public @NotNull List<User> users() {
-        return List.copyOf(users.values());
+    public @NotNull Collection<User> users() {
+        return users.values();
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,5 +7,3 @@ rootProject.name = "chat-chat"
 
 include("api")
 include("plugin")
-
-enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
- User now implements ForwardingAudience.Single (to represent a single Audience) & Identified (which could be useful idk)
- Channel now implements ForwardingAudience

- commands now use the custom User object as the command sender (User == CommandSender, ChatUser == Player, ConsoleUser == ConsoleCommandSender).

With the addition of the ConsoleUser, I've had to move around some of the User stuff to make it work correctly.
- ChatUser has been moved to the API module as an interface, and we now have ChatUserImpl as our backing implementation
- player() and lastMessagedUser() methods from User have been moved to the ChatUser interface

Other changes:
- relocated dependencies
- handled offline players more gracefully, as before calling user.lastMessagedUser().player(), could possibly cause an NPE. So now we remove the lastMessagedUser when they leave the server. if this is to ever throw, something has gone horribly wrong.