### PR TITLE
Added permission to use UTF chars in messages and some more.

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -2,10 +2,7 @@ package at.helpch.chatchat.api.event;
 
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.Format;
-import java.util.Optional;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -4,6 +4,7 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.PMSendEvent;
 import at.helpch.chatchat.util.FormatUtils;
+import at.helpch.chatchat.util.StringUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
@@ -17,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public final class ReplyCommand extends BaseCommand {
 
     private static final String MESSAGE_PERMISSION = "chatchat.pm";
+    private static final String UTF_PERMISSION = "chatchat.utf";
     private final ChatChatPlugin plugin;
 
     public ReplyCommand(@NotNull final ChatChatPlugin plugin) {
@@ -30,6 +32,11 @@ public final class ReplyCommand extends BaseCommand {
 
         if (lastMessaged.isEmpty()) {
             user.sendMessage(Component.text("You have no one to reply to!", NamedTextColor.RED));
+            return;
+        }
+
+        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
+            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
             return;
         }
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -74,10 +74,13 @@ public final class SwitchChannelCommand extends BaseCommand {
             return;
         }
 
+        final var oldChannel = user.channel();
+        user.channel(channel);
         chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
             chatEvent.format(),
             user.player(),
             chatEvent.message()
         ));
+        user.channel(oldChannel);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -2,14 +2,22 @@ package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
+import at.helpch.chatchat.api.event.ChatChatEvent;
+import at.helpch.chatchat.util.FormatUtils;
+import at.helpch.chatchat.util.StringUtils;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Default;
+import dev.triumphteam.cmd.core.annotation.Join;
+import dev.triumphteam.cmd.core.annotation.Optional;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class SwitchChannelCommand extends BaseCommand {
 
+    private static final String UTF_PERMISSION = "chatchat.utf";
     private final ChatChatPlugin plugin;
     private final String command;
 
@@ -20,21 +28,56 @@ public final class SwitchChannelCommand extends BaseCommand {
     }
 
     @Default
-    public void switchChannel(final ChatUser user) {
-
+    public void switchChannel(final ChatUser user, @Join @Optional @NotNull final String message) {
         final var channels = plugin.configManager().channels().channels();
         final var channel = channels.values()
-                .stream()
-                .filter(value -> value.commandName().equals(command))
-                .findAny()
-                .get(); // this should probably only ever throw if the person has changed command names without restarting
+            .stream()
+            .filter(value -> value.commandName().equals(command))
+            .findAny()
+            .get(); // this should probably only ever throw if the person has changed command names without restarting
 
         if (!user.canUse(channel)) {
             user.sendMessage(Component.text("You don't have permission to use this channel!", NamedTextColor.RED));
             return;
         }
 
-        user.channel(channel);
-        user.sendMessage(Component.text("You have switched to the " + command + " channel!", NamedTextColor.GREEN));
+        if (message.isEmpty()) {
+            user.channel(channel);
+            user.sendMessage(Component.text("You have switched to the " + command + " channel!", NamedTextColor.GREEN));
+            return;
+        }
+
+        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
+            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
+            return;
+        }
+
+        final var format = FormatUtils.findFormat(user.player(), plugin.configManager().formats());
+
+        final var audience = plugin.usersHolder().users()
+            .stream()
+            .filter(otherUser -> otherUser.canSee(channel)) // get everyone who can see this channel
+            .collect(Audience.toAudience());
+
+        final var chatEvent = new ChatChatEvent(
+            false,
+            user,
+            audience,
+            format,
+            Component.text(message),
+            channel
+        );
+
+        plugin.getServer().getPluginManager().callEvent(chatEvent);
+
+        if (chatEvent.isCancelled()) {
+            return;
+        }
+
+        chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
+            chatEvent.format(),
+            user.player(),
+            chatEvent.message()
+        ));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -13,7 +13,6 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class SwitchChannelCommand extends BaseCommand {
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -3,8 +3,8 @@ package at.helpch.chatchat.command;
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.PMSendEvent;
-import at.helpch.chatchat.user.ChatUserImpl;
 import at.helpch.chatchat.util.FormatUtils;
+import at.helpch.chatchat.util.StringUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public final class WhisperCommand extends BaseCommand {
 
     private static final String MESSAGE_PERMISSION = "chatchat.pm";
+    private static final String UTF_PERMISSION = "chatchat.utf";
     private final ChatChatPlugin plugin;
 
     public WhisperCommand(@NotNull final ChatChatPlugin plugin) {
@@ -30,6 +31,11 @@ public final class WhisperCommand extends BaseCommand {
 
         if (user.equals(recipient)) {
             user.sendMessage(Component.text("You can't message yourself!", NamedTextColor.RED));
+            return;
+        }
+
+        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
+            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
             return;
         }
 

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -5,8 +5,10 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.ChatChatEvent;
 import at.helpch.chatchat.util.ChannelUtils;
 import at.helpch.chatchat.util.FormatUtils;
+import at.helpch.chatchat.util.StringUtils;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -18,6 +20,7 @@ import java.util.regex.Pattern;
 
 public final class ChatListener implements Listener {
 
+    private static final String UTF_PERMISSION = "chatchat.utf";
     private final ChatChatPlugin plugin;
 
     public ChatListener(@NotNull final ChatChatPlugin plugin) {
@@ -39,6 +42,11 @@ public final class ChatListener implements Listener {
         final var message = channelByPrefix.isEmpty()
                 ? event.getMessage()
                 : event.getMessage().replaceFirst(Pattern.quote(channelByPrefix.get().messagePrefix()), "");
+
+        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
+            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
+            return;
+        }
 
         final var channel = channelByPrefix.isEmpty() || !user.canUse(channelByPrefix.get()) ? user.channel() : channelByPrefix.get();
 

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -70,10 +70,13 @@ public final class ChatListener implements Listener {
             return;
         }
 
+        final var oldChannel = user.channel();
+        user.channel(channel);
         chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
             chatEvent.format(),
             player,
             chatEvent.message()
         ));
+        user.channel(oldChannel);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -2,13 +2,8 @@ package at.helpch.chatchat.listener;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
-import at.helpch.chatchat.api.event.ChatChatEvent;
 import at.helpch.chatchat.util.ChannelUtils;
-import at.helpch.chatchat.util.FormatUtils;
-import at.helpch.chatchat.util.StringUtils;
-import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+import at.helpch.chatchat.util.MessageProcessor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -20,7 +15,6 @@ import java.util.regex.Pattern;
 
 public final class ChatListener implements Listener {
 
-    private static final String UTF_PERMISSION = "chatchat.utf";
     private final ChatChatPlugin plugin;
 
     public ChatListener(@NotNull final ChatChatPlugin plugin) {
@@ -34,8 +28,6 @@ public final class ChatListener implements Listener {
         final var player = event.getPlayer();
         final var user = (ChatUser) plugin.usersHolder().getUser(player);
 
-        final var format = FormatUtils.findFormat(player, plugin.configManager().formats());
-
         final var channelByPrefix =
                 ChannelUtils.findChannelByPrefix(List.copyOf(plugin.configManager().channels().channels().values()), event.getMessage());
 
@@ -43,40 +35,8 @@ public final class ChatListener implements Listener {
                 ? event.getMessage()
                 : event.getMessage().replaceFirst(Pattern.quote(channelByPrefix.get().messagePrefix()), "");
 
-        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
-            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
-            return;
-        }
-
         final var channel = channelByPrefix.isEmpty() || !user.canUse(channelByPrefix.get()) ? user.channel() : channelByPrefix.get();
 
-        final var audience = plugin.usersHolder().users()
-                .stream()
-                .filter(otherUser -> otherUser.canSee(channel)) // get everyone who can see this channel
-                .collect(Audience.toAudience());
-
-        final var chatEvent = new ChatChatEvent(
-                event.isAsynchronous(),
-                user,
-                audience,
-                format,
-                Component.text(message),
-                channel
-        );
-
-        plugin.getServer().getPluginManager().callEvent(chatEvent);
-
-        if (chatEvent.isCancelled()) {
-            return;
-        }
-
-        final var oldChannel = user.channel();
-        user.channel(channel);
-        chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
-            chatEvent.format(),
-            player,
-            chatEvent.message()
-        ));
-        user.channel(oldChannel);
+        MessageProcessor.process(plugin, user, channel, message, event.isAsynchronous());
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
+++ b/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
@@ -1,8 +1,6 @@
 package at.helpch.chatchat.placeholder;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.channel.ChatChannel;
-import at.helpch.chatchat.util.ChannelUtils;
 import java.util.List;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -4,7 +4,6 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.Format;
-import at.helpch.chatchat.api.User;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.util;
 
 import at.helpch.chatchat.channel.ChatChannel;
-import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -1,0 +1,58 @@
+package at.helpch.chatchat.util;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.Channel;
+import at.helpch.chatchat.api.ChatUser;
+import at.helpch.chatchat.api.event.ChatChatEvent;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.jetbrains.annotations.NotNull;
+
+public class MessageProcessor {
+    private static final String UTF_PERMISSION = "chatchat.utf";
+
+    public static void process(
+        @NotNull final ChatChatPlugin plugin,
+        @NotNull final ChatUser user,
+        @NotNull final Channel channel,
+        @NotNull final String message,
+        final boolean async
+    ) {
+        if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
+            user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
+            return;
+        }
+
+        final var format = FormatUtils.findFormat(user.player(), plugin.configManager().formats());
+
+        final var audience = plugin.usersHolder().users()
+            .stream()
+            .filter(otherUser -> otherUser.canSee(channel)) // get everyone who can see this channel
+            .collect(Audience.toAudience());
+
+        final var chatEvent = new ChatChatEvent(
+            async,
+            user,
+            audience,
+            format,
+            Component.text(message),
+            channel
+        );
+
+        plugin.getServer().getPluginManager().callEvent(chatEvent);
+
+        if (chatEvent.isCancelled()) {
+            return;
+        }
+
+        final var oldChannel = user.channel();
+        user.channel(channel);
+        chatEvent.recipients().sendMessage(FormatUtils.parseFormat(
+            chatEvent.format(),
+            user.player(),
+            chatEvent.message()
+        ));
+        user.channel(oldChannel);
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
@@ -3,11 +3,12 @@ package at.helpch.chatchat.util;
 public class StringUtils {
     public static boolean containsIllegalChars(String message) {
         for (char ch : message.toCharArray()) {
-            if (ch > 128 && ch < 167 || ch > 167) {
-                return true;
+            if (ch <= 128 || ch == 167) {
+                continue;
             }
+            return false;
         }
 
-        return false;
+        return true;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
@@ -6,9 +6,9 @@ public class StringUtils {
             if (ch <= 128 || ch == 167) {
                 continue;
             }
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
@@ -1,0 +1,13 @@
+package at.helpch.chatchat.util;
+
+public class StringUtils {
+    public static boolean containsIllegalChars(String message) {
+        for (char ch : message.toCharArray()) {
+            if (ch > 128 && ch < 167 || ch > 167) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
- Users now require the chatchat.utf permission to send messages that contain "illegal chars". It does exactly what DeluxeChat used to, which is to allow chars 0-128 + 167(ascii)
- Added ability to use the `/channel-name` command to send a message: /<channel-name> [message]. This does not switch the channel. Only sends the message. We might need an extra perm for this? Its basically an alternative to the quick prefix.
- Temporarily switch user's channel when they send a message. This is to fix issues when player send message using quick prefix or the /<channel-name> [message] command. This does fix #27 
- Removed unused imports :)