### PR TITLE
Fixes and improvements.

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -3,7 +3,6 @@ package at.helpch.chatchat.api.event;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.Format;
-import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -55,6 +55,14 @@ public final class DefaultConfigObjects {
         return new PMFormat("socialspy", List.of("<gray>(spy) %player_name% <#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
     }
 
+    public static @NotNull String createItemFormat() {
+        return "<gray>[<reset><item><gray> x <amount>]";
+    }
+
+    public static @NotNull String createItemFormatInfo() {
+        return "<dark_gray><item> x <amount>";
+    }
+
     public static @NotNull PMFormat createMentionFormat() {
         return new PMFormat("mention", List.of("<yellow>@%player_name%"));
     }

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -55,14 +55,6 @@ public final class DefaultConfigObjects {
         return new PMFormat("socialspy", List.of("<gray>(spy) %player_name% <#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
     }
 
-    public static @NotNull String createItemFormat() {
-        return "<gray>[<reset><item><gray> x <amount>]";
-    }
-
-    public static @NotNull String createItemFormatInfo() {
-        return "<dark_gray><item> x <amount>";
-    }
-
     public static @NotNull PMFormat createMentionFormat() {
         return new PMFormat("mention", List.of("<yellow>@%player_name%"));
     }

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
@@ -16,6 +16,9 @@ public final class SettingsHolder {
     private PMFormat recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
     private PMFormat socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
 
+    private String itemFormat = DefaultConfigObjects.createItemFormat();
+    private String itemFormatInfo = DefaultConfigObjects.createItemFormatInfo();
+
     private PMFormat mentionFormat = DefaultConfigObjects.createMentionFormat();
     private String mentionPrefix = "@";
     private String globalMentionFormat = "<yellow>";
@@ -32,6 +35,14 @@ public final class SettingsHolder {
 
     public @NotNull PMFormat socialSpyFormat() {
         return socialSpyFormat;
+    }
+
+    public @NotNull String itemFormat() {
+        return itemFormat;
+    }
+
+    public @NotNull String itemFormatInfo() {
+        return itemFormatInfo;
     }
 
     public @NotNull String mentionPrefix() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/SettingsHolder.java
@@ -16,8 +16,8 @@ public final class SettingsHolder {
     private PMFormat recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
     private PMFormat socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
 
-    private String itemFormat = DefaultConfigObjects.createItemFormat();
-    private String itemFormatInfo = DefaultConfigObjects.createItemFormatInfo();
+    private String itemFormat = "<gray>[</gray><item><gray> x <amount>]";
+    private String itemFormatInfo = "<dark_gray><item> x <amount>";
 
     private PMFormat mentionFormat = DefaultConfigObjects.createMentionFormat();
     private String mentionPrefix = "@";

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapMapper.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * A mapper for the channel map, ignoring invalid channels instead of failing entirely.

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
@@ -9,7 +9,6 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
-import java.util.Collections;
 
 public final class ChannelMapper implements TypeSerializer<Channel> {
 

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -36,7 +36,7 @@ public final class ChatListener implements Listener {
         final var channelByPrefix =
                 ChannelUtils.findChannelByPrefix(List.copyOf(plugin.configManager().channels().channels().values()), event.getMessage());
 
-        final var message = channelByPrefix.isEmpty()
+        final var message = channelByPrefix.isEmpty() || !channelByPrefix.get().isUseableBy(user)
                 ? event.getMessage()
                 : event.getMessage().replaceFirst(Pattern.quote(channelByPrefix.get().messagePrefix()), "");
 

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -9,8 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import at.helpch.chatchat.channel.ChatChannel;
-import at.helpch.chatchat.util.ChannelUtils;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
 import org.bukkit.Bukkit;

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -3,16 +3,10 @@ package at.helpch.chatchat.util;
 import at.helpch.chatchat.api.Format;
 import at.helpch.chatchat.config.holders.FormatsHolder;
 import at.helpch.chatchat.format.ChatFormat;
-import java.util.List;
-import java.util.regex.Pattern;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.ComponentLike;
-import net.kyori.adventure.text.TextReplacementConfig;
-import net.kyori.adventure.text.event.ClickEvent;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,21 +16,6 @@ import java.util.Optional;
 
 public final class FormatUtils {
 
-    private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
-    private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
-
-    private static final TextReplacementConfig URL_REPLACER_CONFIG = TextReplacementConfig.builder()
-        .match(DEFAULT_URL_PATTERN)
-        .replacement(builder -> {
-            String clickUrl = builder.content();
-            if (!URL_SCHEME_PATTERN.matcher(clickUrl).find()) {
-                clickUrl = "https://" + clickUrl;
-            }
-            return builder.clickEvent(ClickEvent.openUrl(clickUrl));
-        })
-        .build();
-
-    private static final String URL_PERMISSION = "chatchat.url";
     private static final String FORMAT_PERMISSION = "chatchat.format.";
 
     private FormatUtils() {
@@ -65,10 +44,7 @@ public final class FormatUtils {
             @NotNull final ComponentLike message) {
         return format.parts().stream()
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
-            .map(part -> MessageUtils.parseToMiniMessage(part,
-                Placeholder.component("message", !player.hasPermission(URL_PERMISSION)
-                    ? message
-                    : message.asComponent().replaceText(URL_REPLACER_CONFIG))))
+            .map(part -> MessageUtils.parseToMiniMessage(part, Placeholder.component("message", message)))
             .collect(Component.toComponent());
     }
 
@@ -81,10 +57,7 @@ public final class FormatUtils {
             .map(part -> PlaceholderAPI.setPlaceholders(player, part))
             .map(part -> PlaceholderAPI.setRelationalPlaceholders(player, recipient, part))
             .map(part -> replaceRecipientPlaceholder(recipient, part))
-            .map(part -> MessageUtils.parseToMiniMessage(part,
-                Placeholder.component("message", !player.hasPermission(URL_PERMISSION)
-                    ? message
-                    : message.asComponent().replaceText(URL_REPLACER_CONFIG))))
+            .map(part -> MessageUtils.parseToMiniMessage(part, Placeholder.component("message", message)))
             .collect(Component.toComponent());
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/ItemUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ItemUtils.java
@@ -1,0 +1,145 @@
+package at.helpch.chatchat.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class ItemUtils {
+    private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+
+    public static @NotNull TagResolver.@NotNull Single createItemPlaceholder(
+        @NotNull final String itemFormat,
+        @NotNull final String itemFormatInfo,
+        @NotNull final ItemStack item
+    ) {
+        final var itemPlaceholder = Placeholder.component(
+            "item",
+            Component.text(item.getType().name().toLowerCase(Locale.getDefault()))
+        );
+
+        final var amountPlaceholder = Placeholder.component(
+            "amount",
+            Component.text(item.getAmount())
+        );
+
+        final var hoverInfoComponent = !itemFormatInfo.isBlank()
+            ? MessageUtils.parseToMiniMessage(itemFormatInfo, itemPlaceholder, amountPlaceholder)
+            : null;
+
+        if (item.getType().isAir() || !item.hasItemMeta()) {
+            return Placeholder.component(
+                "item",
+                MessageUtils.parseToMiniMessage(itemFormat, itemPlaceholder, amountPlaceholder).hoverEvent(hoverInfoComponent));
+        }
+
+        final var meta = item.getItemMeta();
+
+        final var name = LEGACY_COMPONENT_SERIALIZER.deserialize(
+            meta.hasDisplayName()
+                ? meta.getDisplayName()
+                : meta.hasLocalizedName()
+                ? meta.getLocalizedName()
+                : item.getType().name().toLowerCase(Locale.getDefault())
+        );
+
+        final var newItemPlaceholder = Placeholder.component("item", name);
+
+        final List<Component> enchants = meta.hasEnchants() && !meta.hasItemFlag(ItemFlag.HIDE_ENCHANTS)
+            ? meta.getEnchants()
+            .entrySet()
+            .stream()
+            .map(entry -> "&7" + formattedEnchantment(entry))
+            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
+            .collect(Collectors.toList())
+            : Collections.emptyList();
+
+        final List<Component> lore = meta.hasLore()
+            ? meta.getLore()
+            .stream()
+            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
+            .map(textComponent -> {
+                if (!textComponent.hasStyling()) {
+                    return textComponent.color(NamedTextColor.DARK_PURPLE);
+                }
+                return textComponent;
+            })
+            .collect(Collectors.toList())
+            : Collections.emptyList();
+
+        final var hoverComponents = new ArrayList<Component>();
+
+        hoverComponents.add(name);
+        hoverComponents.addAll(enchants);
+        hoverComponents.addAll(lore);
+
+        if (hoverInfoComponent != null) {
+            hoverComponents.add(Component.empty());
+            hoverComponents.add(hoverInfoComponent);
+        }
+
+        return Placeholder.component(
+            "item",
+            MessageUtils.parseToMiniMessage(itemFormat, newItemPlaceholder, amountPlaceholder).hoverEvent(
+                hoverComponents.stream().collect(Component.toComponent(Component.newline()))
+            )
+        );
+    }
+
+    private static @NotNull String formattedEnchantment(@NotNull final Map.Entry<Enchantment, Integer> entry) {
+        final var enchantment = entry.getKey();
+        final var value = entry.getValue();
+
+        if (enchantment == null) {
+            return "";
+        }
+
+        final var key = enchantment.getKey().getKey();
+
+        final var enchantmentName = key.substring(0, 1).toUpperCase(Locale.getDefault())
+            + key.substring(1);
+
+        if (enchantment.getMaxLevel() == 1) {
+            return enchantmentName;
+        }
+
+        if (value == null) {
+            return enchantmentName + " I";
+        }
+
+        @NotNull final String roman;
+        switch (value) {
+            case 1:
+                roman = "I";
+                break;
+            case 2:
+                roman = "II";
+                break;
+            case 3:
+                roman = "III";
+                break;
+            case 4:
+                roman = "IV";
+                break;
+            case 5:
+                roman = "V";
+                break;
+            default:
+                roman = value.toString();
+                break;
+        }
+
+        return enchantmentName + " " + roman;
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -4,19 +4,30 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.ChatChatEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 public class MessageProcessor {
+    private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
     private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
     private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
 
@@ -35,7 +46,8 @@ public class MessageProcessor {
     private static final String UTF_PERMISSION = "chatchat.utf";
     private static final String MENTION_PERMISSION = "chatchat.mention";
     private static final String MENTION_EVERYONE_PERMISSION = "chatchat.mention.everyone";
-    private static final String FORMAT_BASE_PERMISSION = "chatchat.tag.";
+    private static final String TAG_BASE_PERMISSION = "chatchat.tag.";
+    private static final String ITEM_PERMISSION = TAG_BASE_PERMISSION + "item";
 
     private static final Map<String, TagResolver> PERMISSION_TAGS = Map.ofEntries(
         Map.entry("click", StandardTags.clickEvent()),
@@ -66,7 +78,7 @@ public class MessageProcessor {
         final var resolver = TagResolver.builder();
 
         for (final var entry : PERMISSION_TAGS.entrySet()) {
-            if (!user.player().hasPermission(FORMAT_BASE_PERMISSION + entry.getKey())) {
+            if (!user.player().hasPermission(TAG_BASE_PERMISSION + entry.getKey())) {
                 continue;
             }
 
@@ -74,11 +86,21 @@ public class MessageProcessor {
         }
 
         for (final var tag : TextDecoration.values()) {
-            if (!user.player().hasPermission(FORMAT_BASE_PERMISSION + tag.toString())) {
+            if (!user.player().hasPermission(TAG_BASE_PERMISSION + tag.toString())) {
                 continue;
             }
 
             resolver.resolver(StandardTags.decorations(tag));
+        }
+
+        if (user.player().hasPermission(ITEM_PERMISSION)) {
+            resolver.resolver(
+                createItemPlaceholder(
+                    plugin.configManager().settings().itemFormat(),
+                    plugin.configManager().settings().itemFormatInfo(),
+                    user.player().getInventory().getItemInMainHand()
+                )
+            );
         }
 
         final var miniMessage = MiniMessage.builder().tags(resolver.build()).build();
@@ -135,5 +157,129 @@ public class MessageProcessor {
             target.sendMessage(transformedComponent);
         }
         user.channel(oldChannel);
+    }
+
+    private static @NotNull TagResolver.@NotNull Single createItemPlaceholder(
+        @NotNull final String itemFormat,
+        @NotNull final String itemFormatInfo,
+        @NotNull final ItemStack item
+    ) {
+        final var itemPlaceholder = Placeholder.component(
+            "item",
+            Component.text(item.getType().name().toLowerCase(Locale.getDefault()))
+        );
+
+        final var amountPlaceholder = Placeholder.component(
+            "amount",
+            Component.text(item.getAmount())
+        );
+
+        final var hoverInfoComponent = !itemFormatInfo.isBlank()
+            ? MessageUtils.parseToMiniMessage(itemFormatInfo, itemPlaceholder, amountPlaceholder)
+            : null;
+
+        if (item.getType().isAir() || !item.hasItemMeta()) {
+            return Placeholder.component(
+                "item",
+                MessageUtils.parseToMiniMessage(itemFormat, itemPlaceholder, amountPlaceholder).hoverEvent(hoverInfoComponent));
+        }
+
+        final var meta = item.getItemMeta();
+
+        final var name = LEGACY_COMPONENT_SERIALIZER.deserialize(
+            meta.hasDisplayName()
+                ? meta.getDisplayName()
+                : meta.hasLocalizedName()
+                ? meta.getLocalizedName()
+                : item.getType().name().toLowerCase(Locale.getDefault())
+        );
+
+        final var newItemPlaceholder = Placeholder.component("item", name);
+
+        final List<Component> enchants = meta.hasEnchants() && !meta.hasItemFlag(ItemFlag.HIDE_ENCHANTS)
+            ? meta.getEnchants()
+            .entrySet()
+            .stream()
+            .map(entry -> "&7" + formattedEnchantment(entry))
+            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
+            .collect(Collectors.toList())
+            : Collections.emptyList();
+
+        final List<Component> lore = meta.hasLore()
+            ? meta.getLore()
+            .stream()
+            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
+            .map(textComponent -> {
+                if (!textComponent.hasStyling()) {
+                    return textComponent.color(NamedTextColor.DARK_PURPLE);
+                }
+                return textComponent;
+            })
+            .collect(Collectors.toList())
+            : Collections.emptyList();
+
+        final var hoverComponents = new ArrayList<Component>();
+
+        hoverComponents.add(name);
+        hoverComponents.addAll(enchants);
+        hoverComponents.addAll(lore);
+
+        if (hoverInfoComponent != null) {
+            hoverComponents.add(Component.empty());
+            hoverComponents.add(hoverInfoComponent);
+        }
+
+        return Placeholder.component(
+            "item",
+            MessageUtils.parseToMiniMessage(itemFormat, newItemPlaceholder, amountPlaceholder).hoverEvent(
+                hoverComponents.stream().collect(Component.toComponent(Component.newline()))
+            )
+        );
+    }
+
+    private static @NotNull String formattedEnchantment(@NotNull final Map.Entry<Enchantment, Integer> entry) {
+        final var enchantment = entry.getKey();
+        final var value = entry.getValue();
+
+        if (enchantment == null) {
+            return "";
+        }
+
+        final var key = enchantment.getKey().getKey();
+
+        final var enchantmentName = key.substring(0, 1).toUpperCase(Locale.getDefault())
+            + key.substring(1);
+
+        if (enchantment.getMaxLevel() == 1) {
+            return enchantmentName;
+        }
+
+        if (value == null) {
+            return enchantmentName + " I";
+        }
+
+        @NotNull final String roman;
+        switch (value) {
+            case 1:
+                roman = "I";
+                break;
+            case 2:
+                roman = "II";
+                break;
+            case 3:
+                roman = "III";
+                break;
+            case 4:
+                roman = "IV";
+                break;
+            case 5:
+                roman = "V";
+                break;
+            default:
+                roman = value.toString();
+                break;
+        }
+
+        return enchantmentName + " " + roman;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -5,7 +5,10 @@ import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.ChatChatEvent;
 import java.util.Map;
+import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -14,10 +17,25 @@ import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import org.jetbrains.annotations.NotNull;
 
 public class MessageProcessor {
+    private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
+    private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
+
+    private static final TextReplacementConfig URL_REPLACER_CONFIG = TextReplacementConfig.builder()
+        .match(DEFAULT_URL_PATTERN)
+        .replacement(builder -> {
+            String clickUrl = builder.content();
+            if (!URL_SCHEME_PATTERN.matcher(clickUrl).find()) {
+                clickUrl = "https://" + clickUrl;
+            }
+            return builder.clickEvent(ClickEvent.openUrl(clickUrl));
+        })
+        .build();
+
+    private static final String URL_PERMISSION = "chatchat.url";
     private static final String UTF_PERMISSION = "chatchat.utf";
     private static final String MENTION_PERMISSION = "chatchat.mention";
     private static final String MENTION_EVERYONE_PERMISSION = "chatchat.mention.everyone";
-    private static final String FORMAT_BASE_PERMISSION = "chatchat.format.";
+    private static final String FORMAT_BASE_PERMISSION = "chatchat.tag.";
 
     private static final Map<String, TagResolver> PERMISSION_TAGS = Map.ofEntries(
         Map.entry("click", StandardTags.clickEvent()),
@@ -34,16 +52,17 @@ public class MessageProcessor {
     );
 
     public static void process(
-            @NotNull final ChatChatPlugin plugin,
-            @NotNull final ChatUser user,
-            @NotNull final Channel channel,
-            @NotNull final String message,
-            final boolean async
+        @NotNull final ChatChatPlugin plugin,
+        @NotNull final ChatUser user,
+        @NotNull final Channel channel,
+        @NotNull final String message,
+        final boolean async
     ) {
         if (StringUtils.containsIllegalChars(message) && !user.player().hasPermission(UTF_PERMISSION)) {
             user.sendMessage(Component.text("You can't use special characters in chat!", NamedTextColor.RED));
             return;
         }
+
         final var resolver = TagResolver.builder();
 
         for (final var entry : PERMISSION_TAGS.entrySet()) {
@@ -63,15 +82,18 @@ public class MessageProcessor {
         }
 
         final var miniMessage = MiniMessage.builder().tags(resolver.build()).build();
+        final var deserializedMessage = !user.player().hasPermission(URL_PERMISSION)
+            ? miniMessage.deserialize(message)
+            : miniMessage.deserialize(message).replaceText(URL_REPLACER_CONFIG);
 
         final var format = FormatUtils.findFormat(user.player(), plugin.configManager().formats());
 
         final var chatEvent = new ChatChatEvent(
-                async,
-                user,
-                format,
-                miniMessage.deserialize(message),
-                channel
+            async,
+            user,
+            format,
+            deserializedMessage,
+            channel
         );
 
         plugin.getServer().getPluginManager().callEvent(chatEvent);
@@ -83,9 +105,9 @@ public class MessageProcessor {
         final var oldChannel = user.channel();
         user.channel(channel);
         var component = FormatUtils.parseFormat(
-                chatEvent.format(),
-                user.player(),
-                chatEvent.message()
+            chatEvent.format(),
+            user.player(),
+            chatEvent.message()
         );
 
         final var mentionPrefix = plugin.configManager().settings().mentionPrefix();

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -4,31 +4,19 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.event.ChatChatEvent;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class MessageProcessor {
-    private static final LegacyComponentSerializer LEGACY_COMPONENT_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
-    private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
+public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
     private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*:");
 
     private static final TextReplacementConfig URL_REPLACER_CONFIG = TextReplacementConfig.builder()
@@ -95,7 +83,7 @@ public class MessageProcessor {
 
         if (user.player().hasPermission(ITEM_PERMISSION)) {
             resolver.resolver(
-                createItemPlaceholder(
+                ItemUtils.createItemPlaceholder(
                     plugin.configManager().settings().itemFormat(),
                     plugin.configManager().settings().itemFormatInfo(),
                     user.player().getInventory().getItemInMainHand()
@@ -157,129 +145,5 @@ public class MessageProcessor {
             target.sendMessage(transformedComponent);
         }
         user.channel(oldChannel);
-    }
-
-    private static @NotNull TagResolver.@NotNull Single createItemPlaceholder(
-        @NotNull final String itemFormat,
-        @NotNull final String itemFormatInfo,
-        @NotNull final ItemStack item
-    ) {
-        final var itemPlaceholder = Placeholder.component(
-            "item",
-            Component.text(item.getType().name().toLowerCase(Locale.getDefault()))
-        );
-
-        final var amountPlaceholder = Placeholder.component(
-            "amount",
-            Component.text(item.getAmount())
-        );
-
-        final var hoverInfoComponent = !itemFormatInfo.isBlank()
-            ? MessageUtils.parseToMiniMessage(itemFormatInfo, itemPlaceholder, amountPlaceholder)
-            : null;
-
-        if (item.getType().isAir() || !item.hasItemMeta()) {
-            return Placeholder.component(
-                "item",
-                MessageUtils.parseToMiniMessage(itemFormat, itemPlaceholder, amountPlaceholder).hoverEvent(hoverInfoComponent));
-        }
-
-        final var meta = item.getItemMeta();
-
-        final var name = LEGACY_COMPONENT_SERIALIZER.deserialize(
-            meta.hasDisplayName()
-                ? meta.getDisplayName()
-                : meta.hasLocalizedName()
-                ? meta.getLocalizedName()
-                : item.getType().name().toLowerCase(Locale.getDefault())
-        );
-
-        final var newItemPlaceholder = Placeholder.component("item", name);
-
-        final List<Component> enchants = meta.hasEnchants() && !meta.hasItemFlag(ItemFlag.HIDE_ENCHANTS)
-            ? meta.getEnchants()
-            .entrySet()
-            .stream()
-            .map(entry -> "&7" + formattedEnchantment(entry))
-            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
-            .collect(Collectors.toList())
-            : Collections.emptyList();
-
-        final List<Component> lore = meta.hasLore()
-            ? meta.getLore()
-            .stream()
-            .map(LEGACY_COMPONENT_SERIALIZER::deserialize)
-            .map(textComponent -> {
-                if (!textComponent.hasStyling()) {
-                    return textComponent.color(NamedTextColor.DARK_PURPLE);
-                }
-                return textComponent;
-            })
-            .collect(Collectors.toList())
-            : Collections.emptyList();
-
-        final var hoverComponents = new ArrayList<Component>();
-
-        hoverComponents.add(name);
-        hoverComponents.addAll(enchants);
-        hoverComponents.addAll(lore);
-
-        if (hoverInfoComponent != null) {
-            hoverComponents.add(Component.empty());
-            hoverComponents.add(hoverInfoComponent);
-        }
-
-        return Placeholder.component(
-            "item",
-            MessageUtils.parseToMiniMessage(itemFormat, newItemPlaceholder, amountPlaceholder).hoverEvent(
-                hoverComponents.stream().collect(Component.toComponent(Component.newline()))
-            )
-        );
-    }
-
-    private static @NotNull String formattedEnchantment(@NotNull final Map.Entry<Enchantment, Integer> entry) {
-        final var enchantment = entry.getKey();
-        final var value = entry.getValue();
-
-        if (enchantment == null) {
-            return "";
-        }
-
-        final var key = enchantment.getKey().getKey();
-
-        final var enchantmentName = key.substring(0, 1).toUpperCase(Locale.getDefault())
-            + key.substring(1);
-
-        if (enchantment.getMaxLevel() == 1) {
-            return enchantmentName;
-        }
-
-        if (value == null) {
-            return enchantmentName + " I";
-        }
-
-        @NotNull final String roman;
-        switch (value) {
-            case 1:
-                roman = "I";
-                break;
-            case 2:
-                roman = "II";
-                break;
-            case 3:
-                roman = "III";
-                break;
-            case 4:
-                roman = "IV";
-                break;
-            case 5:
-                roman = "V";
-                break;
-            default:
-                roman = value.toString();
-                break;
-        }
-
-        return enchantmentName + " " + roman;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageUtils.java
@@ -19,6 +19,10 @@ public final class MessageUtils {
         return miniMessage.deserialize(formatPart, tag);
     }
 
+    public static @NotNull Component parseToMiniMessage(@NotNull final String formatPart, @NotNull final TagResolver... tags) {
+        return miniMessage.deserialize(formatPart, tags);
+    }
+
     public static @NotNull Component parseToMiniMessage(@NotNull final String formatPart, @NotNull final List<TagResolver> tags) {
         return miniMessage.deserialize(formatPart, TagResolver.resolver(tags));
     }

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -13,6 +13,14 @@ social-spy-format:
   parts:
     - '<gray>(spy) %player_name% <#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>'
 
+# The format that the <item> placeholder will use in chat. Needs to contain <item>.
+# Another available internal placeholder is <amount>.
+item-format: '<gray>[<reset><item><gray> x <amount>]'
+
+# Custom line that can show in the hover of the <item> placeholder displaying stuff like item's exact name and amount
+# Set to empty string '' if you want to disable it from ever showing.
+item-format-info: '<dark_gray><item> x <amount>'
+
 # The prefix to use for mentioning players
 mention-prefix: '@'
 

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -15,7 +15,7 @@ social-spy-format:
 
 # The format that the <item> placeholder will use in chat. Needs to contain <item>.
 # Another available internal placeholder is <amount>.
-item-format: '<gray>[<reset><item><gray> x <amount>]'
+item-format: '<gray>[</gray><item><gray> x <amount>]'
 
 # Custom line that can show in the hover of the <item> placeholder displaying stuff like item's exact name and amount
 # Set to empty string '' if you want to disable it from ever showing.


### PR DESCRIPTION
- Fixed the channel quick prefix being removed even if an user had no permission to talk in that specific channel.
- Added support for minimessage tags inside messages. They're all permission based. (chatchat.tag.<option>)
- Moved the URL replacer (the thing that makes url clickable) in the message processor. Seemed to make a bit more sense.
- Added a custom <item> tag that will display the item hold in hand. Its customizable from the settings.

A few notes:

With the addition of the item tag, the plugin will only work 1.13+ since it uses Player#getInventory#getItemInMainHand and this happens every time a message is processed. Since we discussed that's going to be our targeted version anyways, I don't really see why we'd have a fallback. At most tho, we might want to use PAPI's version checker and if its < 1.13 not parse the <item> tag. But I'll let you guys decide.

If you guys think this could be done cleaner (this entire pr lol), please let me know. its currently 4:12 AM so I was half asleep while writing some of this stuff.

That's all. I Think.

Oh one more thing. Before someone asks, the item format info is the line that will show in the hover at the bottom. https://cdn.discordapp.com/attachments/941694626979541002/961779070994120754/unknown.png

It is fully customizable and also can be disabled. It just felt right for some reason.

Ok I Think that's all now.