### PR TITLE
Reworked the mention system

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -120,18 +120,15 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
 
         final var oldChannel = user.channel();
         user.channel(channel);
-        var component = FormatUtils.parseFormat(
-            chatEvent.format(),
-            user.player(),
-            chatEvent.message()
-        );
+
+        final var parsedMessage = chatEvent.message().compact();
 
         final var mentionPrefix = plugin.configManager().settings().mentionPrefix();
         final var mentionSound = plugin.configManager().settings().mentionSound();
         final var mentionFormat = plugin.configManager().settings().mentionFormat();
         final var globalMentionFormat = plugin.configManager().settings().globalMentionFormat();
 
-        var userMessage = component;
+        var userMessage = parsedMessage;
         var userIsTarget = false;
 
         for (final var target : channel.targets(user)) {
@@ -145,7 +142,7 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
                 globalMentionFormat,
                 user,
                 target,
-                component
+                parsedMessage
             );
 
             if (!(target instanceof ChatUser)) {
@@ -162,8 +159,14 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
                 globalMentionProcessResult.getValue()
             );
 
+            var component = FormatUtils.parseFormat(
+                chatEvent.format(),
+                user.player(),
+                mentionProcessResult.getValue()
+            );
+
             if (mentionProcessResult.getKey() || globalMentionProcessResult.getKey()) target.playSound(mentionSound);
-            target.sendMessage(mentionProcessResult.getValue());
+            target.sendMessage(component);
 
             userMessage = processPersonalMentions(
                 mentionPrefix,
@@ -195,8 +198,14 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
             globalMentionProcessResult.getValue()
         );
 
+        var component = FormatUtils.parseFormat(
+            chatEvent.format(),
+            user.player(),
+            mentionProcessResult.getValue()
+        );
+
         if (mentionProcessResult.getKey() || globalMentionProcessResult.getKey()) user.playSound(mentionSound);
-        user.sendMessage(mentionProcessResult.getValue());
+        user.sendMessage(component);
         user.channel(oldChannel);
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -3,7 +3,9 @@ package at.helpch.chatchat.util;
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.api.ChatUser;
+import at.helpch.chatchat.api.User;
 import at.helpch.chatchat.api.event.ChatChatEvent;
+import at.helpch.chatchat.format.PMFormat;
 import java.util.Map;
 import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
@@ -32,10 +34,14 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
 
     private static final String URL_PERMISSION = "chatchat.url";
     private static final String UTF_PERMISSION = "chatchat.utf";
-    private static final String MENTION_PERMISSION = "chatchat.mention";
+    private static final String MENTION_PERSONAL_PERMISSION = "chatchat.mention.personal";
     private static final String MENTION_EVERYONE_PERMISSION = "chatchat.mention.everyone";
+    private static final String MENTION_PERSONAL_BLOCK_PERMISSION = MENTION_PERSONAL_PERMISSION + ".block";
+    private static final String MENTION_EVERYONE_BLOCK_PERMISSION = MENTION_EVERYONE_PERMISSION + ".block";
+    private static final String MENTION_EVERYONE_BLOCK_OVERRIDE_PERMISSION = MENTION_EVERYONE_BLOCK_PERMISSION + ".override";
+    private static final String MENTION_PERSONAL_BLOCK_OVERRIDE_PERMISSION = MENTION_PERSONAL_BLOCK_PERMISSION + ".override";
     private static final String TAG_BASE_PERMISSION = "chatchat.tag.";
-    private static final String ITEM_PERMISSION = TAG_BASE_PERMISSION + "item";
+    private static final String ITEM_TAG_PERMISSION = TAG_BASE_PERMISSION + "item";
 
     private static final Map<String, TagResolver> PERMISSION_TAGS = Map.ofEntries(
         Map.entry("click", StandardTags.clickEvent()),
@@ -81,7 +87,7 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
             resolver.resolver(StandardTags.decorations(tag));
         }
 
-        if (user.player().hasPermission(ITEM_PERMISSION)) {
+        if (user.player().hasPermission(ITEM_TAG_PERMISSION)) {
             resolver.resolver(
                 ItemUtils.createItemPlaceholder(
                     plugin.configManager().settings().itemFormat(),
@@ -123,27 +129,132 @@ public class MessageProcessor { private static final Pattern DEFAULT_URL_PATTERN
         final var mentionPrefix = plugin.configManager().settings().mentionPrefix();
         final var mentionSound = plugin.configManager().settings().mentionSound();
         final var mentionFormat = plugin.configManager().settings().mentionFormat();
-        var mentionEveryone = false;
+        final var globalMentionFormat = plugin.configManager().settings().globalMentionFormat();
 
-        if (user.player().hasPermission(MENTION_EVERYONE_PERMISSION)) {
-            final var replaced = MentionUtils.replaceMention(mentionPrefix + "(everyone|here|channel)",
-                    component, plugin.configManager().settings().globalMentionFormat());
-            component = replaced.component();
-            mentionEveryone = replaced.didReplace();
-        }
+        var userMessage = component;
+        var userIsTarget = false;
 
         for (final var target : channel.targets(user)) {
-            var mention = mentionEveryone;
-            var transformedComponent = component;
-            if (target instanceof ChatUser && user.player().hasPermission(MENTION_PERMISSION)) {
-                final var replaced = MentionUtils.replaceMention((ChatUser) target, mentionPrefix,
-                        component, mentionFormat);
-                mention = replaced.didReplace() || mention;
-                transformedComponent = replaced.component();
+            if (target.uuid() == user.uuid()) {
+                userIsTarget = true;
+                continue;
             }
-            if (mention) target.playSound(mentionSound);
-            target.sendMessage(transformedComponent);
+
+            final var globalMentionProcessResult = processGlobalMentions(
+                mentionPrefix,
+                globalMentionFormat,
+                user,
+                target,
+                component
+            );
+
+            if (!(target instanceof ChatUser)) {
+                if (globalMentionProcessResult.getKey()) target.playSound(mentionSound);
+                target.sendMessage(globalMentionProcessResult.getValue());
+                continue;
+            }
+
+            final var mentionProcessResult = processPersonalMentions(
+                mentionPrefix,
+                mentionFormat,
+                user,
+                (ChatUser) target,
+                globalMentionProcessResult.getValue()
+            );
+
+            if (mentionProcessResult.getKey() || globalMentionProcessResult.getKey()) target.playSound(mentionSound);
+            target.sendMessage(mentionProcessResult.getValue());
+
+            userMessage = processPersonalMentions(
+                mentionPrefix,
+                mentionFormat,
+                user,
+                (ChatUser) target,
+                userMessage
+            ).getValue();
         }
+
+        if (!userIsTarget) {
+            user.channel(oldChannel);
+            return;
+        }
+
+        final var globalMentionProcessResult = processGlobalMentions(
+            mentionPrefix,
+            globalMentionFormat,
+            user,
+            user,
+            userMessage
+        );
+
+        final var mentionProcessResult = processPersonalMentions(
+            mentionPrefix,
+            mentionFormat,
+            user,
+            user,
+            globalMentionProcessResult.getValue()
+        );
+
+        if (mentionProcessResult.getKey() || globalMentionProcessResult.getKey()) user.playSound(mentionSound);
+        user.sendMessage(mentionProcessResult.getValue());
         user.channel(oldChannel);
+    }
+
+    private static @NotNull Map.Entry<@NotNull Boolean, @NotNull Component> processGlobalMentions(
+        @NotNull final String mentionPrefix,
+        @NotNull final String globalMentionFormat,
+        @NotNull final ChatUser user,
+        @NotNull final User target,
+        @NotNull final Component message
+    ) {
+        if (!user.player().hasPermission(MENTION_EVERYONE_PERMISSION)) {
+            return Map.entry(false, message);
+        }
+
+        if (target instanceof ChatUser) {
+            final var targetChatUser = (ChatUser) target;
+
+            if (targetChatUser.player().hasPermission(MENTION_EVERYONE_BLOCK_PERMISSION) && !user.player().hasPermission(MENTION_EVERYONE_BLOCK_OVERRIDE_PERMISSION)) {
+                return Map.entry(false, message);
+            }
+
+            final var replaced = MentionUtils.replaceMention(
+                mentionPrefix + "(everyone|here|channel)",
+                message,
+                globalMentionFormat);
+
+            return Map.entry(replaced.didReplace(), replaced.component());
+        }
+
+        final var replaced = MentionUtils.replaceMention(
+            mentionPrefix + "(everyone|here|channel)",
+            message,
+            globalMentionFormat);
+
+        return Map.entry(replaced.didReplace(), replaced.component());
+    }
+
+    private static @NotNull Map.Entry<@NotNull Boolean, @NotNull Component> processPersonalMentions(
+        @NotNull final String mentionPrefix,
+        @NotNull final PMFormat mentionFormat,
+        @NotNull final ChatUser user,
+        @NotNull final ChatUser target,
+        @NotNull final Component message
+    ) {
+        if (!user.player().hasPermission(MENTION_PERSONAL_PERMISSION) ||
+            (target.player().hasPermission(MENTION_PERSONAL_BLOCK_PERMISSION) &&
+                !user.player().hasPermission(MENTION_PERSONAL_BLOCK_OVERRIDE_PERMISSION))
+        ) {
+            return Map.entry(false, message);
+        }
+
+        final var replaced = MentionUtils.replaceMention(
+            target,
+            mentionPrefix,
+            message,
+            mentionFormat
+        );
+
+        return Map.entry(replaced.didReplace(), replaced.component());
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/StringUtils.java
@@ -3,7 +3,7 @@ package at.helpch.chatchat.util;
 public class StringUtils {
     public static boolean containsIllegalChars(String message) {
         for (char ch : message.toCharArray()) {
-            if (ch <= 128 || ch == 167) {
+            if (ch <= 127 || ch == 167) {
                 continue;
             }
             return true;


### PR DESCRIPTION
- Added permissions to block mentions coming to user (global or personal)
- Added permission to override that block
- Fixed personal mentions only showing to the receiver and not the sender as well

There's still a couple problems with the mention system however:
- When an item is named <mention-prefix><online-player-name/everyone> and the player uses the item tag inside their message, it will act like a mention.
- When the chat message has gradients or rainbows the mentions won't be picked up. I believe this is the same problem we used to have for the %message% tag (might need to confirm with the kyori team again if its a bug or not. I Don't remember what the outcome of the discussion last time was.) EDIT: After some tests turns out the problem is that the Component#replaceText method looks thru each component and their children independently and doesn't compress them as I first assumed.

I don't know if I'll get a solution in this PR but if you guys have ideas please share

Forgot to mention that this closes #50 