### PR TITLE
Better Formats, DM Toggling

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
+++ b/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
@@ -13,4 +13,8 @@ public interface ChatUser extends User {
     @NotNull Optional<ChatUser> lastMessagedUser();
 
     void lastMessagedUser(@Nullable final ChatUser user);
+
+    boolean privateMessages();
+
+    void privateMessages(final boolean enable);
 }

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -10,6 +10,7 @@ import at.helpch.chatchat.command.ReplyCommand;
 import at.helpch.chatchat.command.SocialSpyCommand;
 import at.helpch.chatchat.command.SwitchChannelCommand;
 import at.helpch.chatchat.command.WhisperCommand;
+import at.helpch.chatchat.command.WhisperToggleCommand;
 import at.helpch.chatchat.config.ConfigManager;
 import at.helpch.chatchat.hooks.HookManager;
 import at.helpch.chatchat.listener.ChatListener;
@@ -116,6 +117,7 @@ public final class ChatChatPlugin extends JavaPlugin {
                 new ReloadCommand(this),
                 whisperCommand,
                 new ReplyCommand(this, whisperCommand),
+                new WhisperToggleCommand(this),
                 new SocialSpyCommand(this)
         ).forEach(commandManager::registerCommand);
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -31,8 +31,18 @@ public final class WhisperCommand extends BaseCommand {
     @Permission(MESSAGE_PERMISSION)
     public void whisperCommand(final ChatUser user, final ChatUser recipient, @Join final String message) {
 
+        if (!user.privateMessages()) {
+            user.sendMessage(plugin.configManager().messages().repliesDisabled());
+            return;
+        }
+
         if (user.equals(recipient)) {
             user.sendMessage(plugin.configManager().messages().cantMessageYourself());
+            return;
+        }
+
+        if (!recipient.privateMessages()) {
+            user.sendMessage(plugin.configManager().messages().targetRepliesDisabled());
             return;
         }
 

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperToggleCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperToggleCommand.java
@@ -1,0 +1,34 @@
+package at.helpch.chatchat.command;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
+import dev.triumphteam.cmd.bukkit.annotation.Permission;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.jetbrains.annotations.NotNull;
+
+@Command(value = "togglemsg", alias = { "toggledms", "toglepms" })
+public class WhisperToggleCommand extends BaseCommand {
+
+    private static final String MESSAGE_TOGGLE_PERMISSION = "chatchat.pm.toggle";
+
+    private final ChatChatPlugin plugin;
+
+    public WhisperToggleCommand(@NotNull final ChatChatPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Default
+    @Permission(MESSAGE_TOGGLE_PERMISSION)
+    public void whisperToggleCommand(final ChatUser user) {
+        user.privateMessages(!user.privateMessages());
+
+        if (user.privateMessages()) {
+            user.sendMessage(plugin.configManager().messages().privateMessagesEnabled());
+            return;
+        }
+
+        user.sendMessage(plugin.configManager().messages().privateMessagesDisabled());
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/MessagesHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/MessagesHolder.java
@@ -15,6 +15,10 @@ public final class MessagesHolder {
 
     // messaging related
     private Component noReplies = text("You have no one to reply to!", RED);
+    private Component repliesDisabled = text("You can't send private messages while they're disabled!", RED);
+    private Component targetRepliesDisabled = text("This user has their private messages disabled!", RED);
+    private Component privateMessagesEnabled = text("Your private messages have been enabled!", GREEN);
+    private Component privateMessagesDisabled = text("Your private messages have been disabled!", RED);
     private Component cantMessageYourself = text("You can't message yourself!", RED);
     private Component specialCharactersNoPermission = text("You do not have permission to use special characters!", RED);
     private Component socialSpyEnabled = text("Social spy enabled", GREEN);
@@ -34,8 +38,24 @@ public final class MessagesHolder {
         return noReplies;
     }
 
+    public @NotNull Component repliesDisabled() {
+        return repliesDisabled;
+    }
+
+    public @NotNull Component targetRepliesDisabled() {
+        return targetRepliesDisabled;
+    }
+
     public @NotNull Component cantMessageYourself() {
         return cantMessageYourself;
+    }
+
+    public @NotNull Component privateMessagesEnabled() {
+        return privateMessagesEnabled;
+    }
+
+    public @NotNull Component privateMessagesDisabled() {
+        return privateMessagesDisabled;
     }
 
     public @NotNull Component specialCharactersNoPermission() {

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -15,6 +15,8 @@ import java.util.regex.Pattern;
 
 public final class ChatListener implements Listener {
 
+    private static final Pattern LEGACY_COLOR_PATTERN = Pattern.compile("§[\\da-f]");
+    private static final Pattern LEGACY_HEX_COLOR_PATTERN = Pattern.compile("§x(§[\\da-fA-F]){6}");
     private final ChatChatPlugin plugin;
 
     public ChatListener(@NotNull final ChatChatPlugin plugin) {
@@ -30,6 +32,8 @@ public final class ChatListener implements Listener {
             event.setCancelled(true);
         }
 
+        event.setMessage(cleanseMessage(event.getMessage()));
+
         final var player = event.getPlayer();
         final var user = (ChatUser) plugin.usersHolder().getUser(player);
 
@@ -43,5 +47,12 @@ public final class ChatListener implements Listener {
         final var channel = channelByPrefix.isEmpty() || !channelByPrefix.get().isUseableBy(user) ? user.channel() : channelByPrefix.get();
 
         MessageProcessor.process(plugin, user, channel, message, event.isAsynchronous());
+    }
+
+    private static String cleanseMessage(@NotNull final String message) {
+        // TODO: Maybe kyorify instead
+        return LEGACY_COLOR_PATTERN.matcher(
+            LEGACY_HEX_COLOR_PATTERN.matcher(message).replaceAll("")
+        ).replaceAll("");
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -21,7 +21,7 @@ public final class ChatListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onChat(final AsyncPlayerChatEvent event) {
         try {
             event.getRecipients().clear();

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -24,6 +24,7 @@ public final class ChatUserImpl implements ChatUser {
 
     private @NotNull final UUID uuid;
     private ChatUser lastMessaged;
+    private boolean privateMessages = true;
     private Channel channel;
     private Format format;
 
@@ -60,6 +61,16 @@ public final class ChatUserImpl implements ChatUser {
     @Override
     public void lastMessagedUser(@Nullable final ChatUser user) {
         this.lastMessaged = user;
+    }
+
+    @Override
+    public boolean privateMessages() {
+        return privateMessages;
+    }
+
+    @Override
+    public void privateMessages(final boolean enabled) {
+        this.privateMessages = enabled;
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -41,10 +41,10 @@ public final class FormatUtils {
             @NotNull final Format format,
             @NotNull final Player player,
             @NotNull final ComponentLike message) {
-        return format.parts().stream()
-            .map(part -> PlaceholderAPI.setPlaceholders(player, part))
-            .map(part -> MessageUtils.parseToMiniMessage(part, Placeholder.component("message", message)))
-            .collect(Component.toComponent());
+        return MessageUtils.parseToMiniMessage(
+            PlaceholderAPI.setPlaceholders(player, String.join("", format.parts())),
+            Placeholder.component("message", message)
+        );
     }
 
     public static @NotNull Component parseFormat(
@@ -52,12 +52,17 @@ public final class FormatUtils {
         @NotNull final Player player,
         @NotNull final Player recipient,
         @NotNull final ComponentLike message) {
-        return format.parts().stream()
-            .map(part -> PlaceholderAPI.setPlaceholders(player, part))
-            .map(part -> PlaceholderAPI.setRelationalPlaceholders(player, recipient, part))
-            .map(part -> replaceRecipientPlaceholder(recipient, part))
-            .map(part -> MessageUtils.parseToMiniMessage(part, Placeholder.component("message", message)))
-            .collect(Component.toComponent());
+        return MessageUtils.parseToMiniMessage(
+            replaceRecipientPlaceholder(
+                recipient,
+                PlaceholderAPI.setRelationalPlaceholders(
+                    player,
+                    recipient,
+                    PlaceholderAPI.setPlaceholders(player, String.join("", format.parts()))
+                )
+            ),
+            Placeholder.component("message", message)
+        );
     }
 
     private static @NotNull String replaceRecipientPlaceholder(@NotNull final Player player, @NotNull final String toReplace) {

--- a/plugin/src/main/resources/messages.yml
+++ b/plugin/src/main/resources/messages.yml
@@ -1,6 +1,10 @@
 # https://wiki.helpch.at
 
 no-replies: <red>You have no one to reply to!
+replies-disabled: You can't send private messages while they're disabled!
+target-replies-disabled: <red>This user has their private messages disabled!
+private-messages-enabled: <green>Your private messages have been enabled!
+private-messages-disabled: <red>Your private messages have been disabled!
 cant-message-yourself: <red>You can't message yourself!
 special-characters-no-permission: <red>You do not have permission to use special characters!
 social-spy-enabled: <green>Social spy enabled


### PR DESCRIPTION
- The chat listener is at the highest priority now. (The chat formatting plugin should be the last to handle the messages imo)
- Added better formats (appending the parts before deserialization)
- Added a way to toggle personal DMs. (unfortunately it resets when the player reconnects. same as channels since we're not storing anything user related yet)
- Cleanse messages before processing them. This is possibly a temporary solution until a better one is found. This just removes legacy color codes from the actual message. 