### PR TITLE
Made the format parts a Map<String, List<String>>

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/Format.java
+++ b/api/src/main/java/at/helpch/chatchat/api/Format.java
@@ -3,6 +3,7 @@ package at.helpch.chatchat.api;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
 
 public interface Format {
 
@@ -14,7 +15,7 @@ public interface Format {
 
     @NotNull Format priority(final int priority);
 
-    @NotNull List<String> parts();
+    @NotNull Map<String, List<String>> parts();
 
-    @NotNull Format parts(@NotNull final List<String> parts);
+    @NotNull Format parts(@NotNull final Map<String, List<String>> parts);
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ spigot = "1.18.1-R0.1-SNAPSHOT"
 
 # Adventure
 minimessage = "4.10.1"
-adventure-platform = "4.0.1"
+adventure-platform = "4.1.0"
 
 # Other
 configurate = "4.1.2"

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -16,47 +17,90 @@ public final class DefaultConfigObjects {
 
     public static @NotNull ChatChannel createDefaultChannel() {
         return new ChatChannel("default",
-                "", "global", "<gray>[<blue>Global<gray>]");
+            "", "global", "<gray>[<blue>Global<gray>]");
     }
 
     public static @NotNull ChatChannel createStaffChannel() {
-        return new ChatChannel("staff", "@", "staffchat", "<gray>[<green>Staff<gray>]");
+        return new ChatChannel("staff",
+            "@", "staffchat", "<gray>[<green>Staff<gray>]");
     }
 
     public static @NotNull ChatFormat createDefaultFormat() {
-        return new ChatFormat("default", 2,
-                List.of(
-                        "%chatchat_channel_prefix% ",
-                        "<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] ",
-                        "<white>%player_name% ",
-                        "<gray>» ",
-                        "<white><message>"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("channel", List.of("%chatchat_channel_prefix% "));
+        map.put("prefix", List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] "));
+        map.put("name", List.of("<white>%player_name%"));
+        map.put("message", List.of(" <gray>» <white><message>"));
+
+        return new ChatFormat("default", 2, map);
     }
 
     public static @NotNull ChatFormat createOtherFormat() {
-        return new ChatFormat("other", 1,
-                List.of(
-                        "%chatchat_channel_prefix% ",
-                        "<hover:show_text:\"Prefix: %vault_group%\"><gray>[<gradient:#40c9ff:#e81cff>ChatChat<gray>] ",
-                        "<rainbow>%player_name% ",
-                        "<gray>» ",
-                        "<white><message>"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("channel", List.of("%chatchat_channel_prefix% "));
+        map.put("prefix", List.of("<gray>[<gradient:#40c9ff:#e81cff>ChatChat<gray>] "));
+        map.put(
+            "name",
+            List.of(
+                "<hover:show_text:\"Prefix: %vault_group%\">",
+                "<rainbow>%player_name%",
+                "</hover>"
+            )
+        );
+        map.put("message", List.of(" <gray>» <white><message>"));
+
+        return new ChatFormat("other", 1, map);
     }
 
     public static @NotNull PMFormat createPrivateMessageSenderFormat() {
-        return new PMFormat("sender", List.of("<gray>you <color:#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("sender", List.of("<gray>you"));
+        map.put("separator", List.of(" <color:#40c9ff>-> "));
+        map.put("recipient", List.of("<gray>%recipient_player_name%"));
+        map.put("message", List.of(" <#e81cff>» <white><message>"));
+
+        return new PMFormat("sender", map);
     }
 
     public static @NotNull PMFormat createPrivateMessageRecipientFormat() {
-        return new PMFormat("recipient", List.of("<gray>%player_name% <#40c9ff>-> <gray>you <#e81cff>» <white><message>"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("sender", List.of("<gray>%player_name%"));
+        map.put("separator", List.of(" <#40c9ff>-> "));
+        map.put("recipient", List.of("<gray>you"));
+        map.put("message", List.of(" <#e81cff>» <white><message>"));
+
+        return new PMFormat("recipient", map);
     }
 
     public static @NotNull PMFormat createPrivateMessageSocialSpyFormat() {
-        return new PMFormat("socialspy", List.of("<gray>(spy) %player_name% <#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("prefix", List.of("<gray>(spy) "));
+        map.put("sender", List.of("%player_name%"));
+        map.put("separator", List.of(" <#40c9ff>-> "));
+        map.put("recipient", List.of("<gray>%recipient_player_name%"));
+        map.put("message", List.of(" <#e81cff>» <white><message>"));
+
+        return new PMFormat("socialspy", map);
     }
 
     public static @NotNull PMFormat createMentionFormat() {
-        return new PMFormat("mention", List.of("<yellow>@%player_name%"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put(
+            "name",
+            List.of(
+                "<hover:show_text:\"<gold>This is a mention!\">",
+                "<yellow>@%player_name%",
+                "</hover>"
+            )
+        );
+
+        return new PMFormat("mention", map);
     }
 
     public static @NotNull Sound createMentionSound() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -59,7 +59,7 @@ public final class DefaultConfigObjects {
 
         map.put("sender", List.of("<gray>you"));
         map.put("separator", List.of(" <color:#40c9ff>-> "));
-        map.put("recipient", List.of("<gray>%recipient_player_name%"));
+        map.put("recipient", List.of("<gray><recipient:player_name>"));
         map.put("message", List.of(" <#e81cff>» <white><message>"));
 
         return new PMFormat("sender", map);
@@ -82,7 +82,7 @@ public final class DefaultConfigObjects {
         map.put("prefix", List.of("<gray>(spy) "));
         map.put("sender", List.of("%player_name%"));
         map.put("separator", List.of(" <#40c9ff>-> "));
-        map.put("recipient", List.of("<gray>%recipient_player_name%"));
+        map.put("recipient", List.of("<gray><recipient:player_name>"));
         map.put("message", List.of(" <#e81cff>» <white><message>"));
 
         return new PMFormat("socialspy", map);

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChatFormatMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChatFormatMapper.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.config.mapper;
 
 import at.helpch.chatchat.format.ChatFormat;
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -8,9 +9,12 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public final class ChatFormatMapper implements TypeSerializer<ChatFormat> {
 
+    private static final TypeToken<Map<String, List<String>>> mapTypeToken = new TypeToken<>() {};
     private static final String PRIORITY = "priority";
     private static final String PARTS = "parts";
 
@@ -31,7 +35,7 @@ public final class ChatFormatMapper implements TypeSerializer<ChatFormat> {
 
         final var priority = nonVirtualNode(node, PRIORITY).getInt();
 
-        final var parts = nonVirtualNode(node, PARTS).getList(String.class);
+        final var parts = nonVirtualNode(node, PARTS).get(mapTypeToken);
         if (parts == null) {
             throw new SerializationException("Parts list of node: " + key + " cannot be null!");
         }

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/PMFormatMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/PMFormatMapper.java
@@ -1,6 +1,7 @@
 package at.helpch.chatchat.config.mapper;
 
 import at.helpch.chatchat.format.PMFormat;
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -8,9 +9,12 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public final class PMFormatMapper implements TypeSerializer<PMFormat> {
 
+    private static final TypeToken<Map<String, List<String>>> mapTypeToken = new TypeToken<>() {};
     private static final String PARTS = "parts";
 
     private ConfigurationNode nonVirtualNode(final ConfigurationNode source, final Object... path) throws SerializationException {
@@ -28,7 +32,7 @@ public final class PMFormatMapper implements TypeSerializer<PMFormat> {
         }
         final var key = keyNode.toString();
 
-        final var parts = nonVirtualNode(node, PARTS).getList(String.class);
+        final var parts = nonVirtualNode(node, PARTS).get(mapTypeToken);
         if (parts == null) {
             throw new SerializationException("Parts list of node: " + key + " cannot be null!");
         }

--- a/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/ChatFormat.java
@@ -4,7 +4,9 @@ import at.helpch.chatchat.api.Format;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @ConfigSerializable
 public final class ChatFormat implements Format {
@@ -12,12 +14,12 @@ public final class ChatFormat implements Format {
     private static ChatFormat defaultFormat = DefaultFormatFactory.createDefaultFormat();
     private final String name;
     private final int priority;
-    private final List<String> parts;
+    private final Map<String, List<String>> parts;
 
-    public ChatFormat(@NotNull final String name, final int priority, @NotNull final List<String> parts) {
+    public ChatFormat(@NotNull final String name, final int priority, @NotNull final Map<String, List<String>> parts) {
         this.name = name;
         this.priority = priority;
-        this.parts = parts;
+        this.parts = Collections.unmodifiableMap(parts);
     }
 
     @Override
@@ -31,12 +33,12 @@ public final class ChatFormat implements Format {
     }
 
     @Override
-    public @NotNull List<String> parts() {
-        return List.copyOf(parts);
+    public @NotNull Map<String, List<String>> parts() {
+        return parts;
     }
 
     @Override
-    public @NotNull ChatFormat parts(@NotNull final List<String> parts) {
+    public @NotNull ChatFormat parts(@NotNull final Map<String, List<String>> parts) {
         return new ChatFormat(name, priority, parts);
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/DefaultFormatFactory.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.format;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public final class DefaultFormatFactory {
@@ -12,8 +13,13 @@ public final class DefaultFormatFactory {
     B - The default-format config option isn't set correctly
      */
     public static @NotNull ChatFormat createDefaultFormat() {
-        return new ChatFormat("default", 1,
-                List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] %player_name% » %message%"));
+        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
+
+        map.put("prefix", List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] "));
+        map.put("name", List.of("<white>%player_name%"));
+        map.put("message", List.of(" <gray>» <white><message>"));
+
+        return new ChatFormat("default", 2, map);
     }
 
 }

--- a/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/PMFormat.java
@@ -4,17 +4,19 @@ import at.helpch.chatchat.api.Format;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @ConfigSerializable
 public final class PMFormat implements Format {
 
     private final String name;
-    private final List<String> parts;
+    private final Map<String, List<String>> parts;
 
-    public PMFormat(@NotNull final String name, @NotNull final List<String> parts) {
+    public PMFormat(@NotNull final String name, @NotNull final Map<String, List<String>> parts) {
         this.name = name;
-        this.parts = parts;
+        this.parts = Collections.unmodifiableMap(parts);
     }
 
     @Override
@@ -38,12 +40,12 @@ public final class PMFormat implements Format {
     }
 
     @Override
-    public @NotNull List<String> parts() {
+    public @NotNull Map<String, List<String>> parts() {
         return parts;
     }
 
     @Override
-    public @NotNull PMFormat parts(@NotNull final List<String> parts) {
+    public @NotNull PMFormat parts(@NotNull final Map<String, List<String>> parts) {
         return new PMFormat(name, parts);
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 
 public final class ChatListener implements Listener {
 
-    private static final Pattern LEGACY_COLOR_PATTERN = Pattern.compile("§[\\da-f]");
+    private static final Pattern LEGACY_FORMATS_PATTERN = Pattern.compile("§[\\da-fk-or]");
     private static final Pattern LEGACY_HEX_COLOR_PATTERN = Pattern.compile("§x(§[\\da-fA-F]){6}");
     private final ChatChatPlugin plugin;
 
@@ -50,8 +50,8 @@ public final class ChatListener implements Listener {
     }
 
     private static String cleanseMessage(@NotNull final String message) {
-        return LEGACY_COLOR_PATTERN.matcher(
+        return LEGACY_FORMATS_PATTERN.matcher(
             LEGACY_HEX_COLOR_PATTERN.matcher(message).replaceAll("")
-        ).replaceAll("");
+        ).replaceAll("").replace("§", "");
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -50,11 +50,6 @@ public final class ChatListener implements Listener {
     }
 
     private static String cleanseMessage(@NotNull final String message) {
-        // TODO: Maybe kyorify instead. The issues with that is they will only work if the player has permission for
-        //  chat colors anyways.
-        //  There's an updated. We might be able to use
-        //  https://jd.adventure.kyori.net/text-minimessage/4.10.1/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.html#parsed(java.lang.String,java.lang.String)
-        //
         return LEGACY_COLOR_PATTERN.matcher(
             LEGACY_HEX_COLOR_PATTERN.matcher(message).replaceAll("")
         ).replaceAll("");

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -52,6 +52,9 @@ public final class ChatListener implements Listener {
     private static String cleanseMessage(@NotNull final String message) {
         // TODO: Maybe kyorify instead. The issues with that is they will only work if the player has permission for
         //  chat colors anyways.
+        //  There's an updated. We might be able to use
+        //  https://jd.adventure.kyori.net/text-minimessage/4.10.1/net/kyori/adventure/text/minimessage/tag/resolver/Placeholder.html#parsed(java.lang.String,java.lang.String)
+        //
         return LEGACY_COLOR_PATTERN.matcher(
             LEGACY_HEX_COLOR_PATTERN.matcher(message).replaceAll("")
         ).replaceAll("");

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -50,7 +50,8 @@ public final class ChatListener implements Listener {
     }
 
     private static String cleanseMessage(@NotNull final String message) {
-        // TODO: Maybe kyorify instead
+        // TODO: Maybe kyorify instead. The issues with that is they will only work if the player has permission for
+        //  chat colors anyways.
         return LEGACY_COLOR_PATTERN.matcher(
             LEGACY_HEX_COLOR_PATTERN.matcher(message).replaceAll("")
         ).replaceAll("");

--- a/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
+++ b/plugin/src/main/java/at/helpch/chatchat/placeholder/ChatPlaceholders.java
@@ -2,6 +2,7 @@ package at.helpch.chatchat.placeholder;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import java.util.List;
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
@@ -43,7 +44,7 @@ public final class ChatPlaceholders extends PlaceholderExpansion {
 
     @Override
     public String onRequest(final OfflinePlayer offlinePlayer, @NotNull final String input) {
-        final var params = input.split("_");
+        final var params = PlaceholderAPI.setBracketPlaceholders(offlinePlayer, input).split("_");
 
         if (offlinePlayer == null) {
             return "";

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class FormatUtils {
     private static final String FORMAT_PERMISSION = "chatchat.format.";
@@ -42,7 +43,14 @@ public final class FormatUtils {
             @NotNull final Player player,
             @NotNull final ComponentLike message) {
         return MessageUtils.parseToMiniMessage(
-            PlaceholderAPI.setPlaceholders(player, String.join("", format.parts())),
+            PlaceholderAPI.setPlaceholders(
+                player,
+                format.parts()
+                    .values()
+                    .stream()
+                    .map(part -> String.join("", part))
+                    .collect(Collectors.joining())
+            ),
             Placeholder.component("message", message)
         );
     }
@@ -58,7 +66,14 @@ public final class FormatUtils {
                 PlaceholderAPI.setRelationalPlaceholders(
                     player,
                     recipient,
-                    PlaceholderAPI.setPlaceholders(player, String.join("", format.parts()))
+                    PlaceholderAPI.setPlaceholders(
+                        player,
+                        format.parts()
+                            .values()
+                            .stream()
+                            .map(part -> String.join("", part))
+                            .collect(Collectors.joining())
+                    )
                 )
             ),
             Placeholder.component("message", message)
@@ -76,8 +91,8 @@ public final class FormatUtils {
             toReplace
                 .replace("%recipient%", player.getName())
                 // This is to support PAPI placeholders for the recipient. Ex: %recipient_player_name%.
-                // I know it can be better and probably needs a complex parser but that requires, time, skills and patience,
-                // none of which I actually have.
+                // TODO: Improve this. We need an actual parser for this instead of this. Possibly an even better idea
+                //  is to use MiniMessage tags instead.
                 .replace("%recipient_", "%")
             );
     }

--- a/plugin/src/main/resources/formats.yml
+++ b/plugin/src/main/resources/formats.yml
@@ -3,22 +3,52 @@ default-format: 'default'
 formats:
   default: # this is the default format as set by default-format. No permission is needed.
     priority: 2 # lower number = higher priority
-    # list of all the segments of the format, supports unlimited amount of segments.
-    # Technically only 1 line is needed, but to clean up the config, multiple lines can be used
+    # list of all the parts of the format, supports unlimited amount of parts.
+    # Technically only 1 part is needed and every part only needs one line but to clean up the config, multiple parts
+    # can be used and each part can have multiple lines.
     # These parts can be formatted using MiniMessage, which can be found here: https://docs.adventure.kyori.net/minimessage/index.html
     parts:
-      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%chatchat_channel_prefix%</hover></click>'
-      - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> [%vault_group%]</hover>'
-      - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> %player_displayname%</hover>'
-      - '<hover:show_text:"Cool diver tooltip here"> ></hover>'
-      - '<message>'
-      - '<hover:show_text:"This forces everyone to have a ! on the end. Haha">!</hover>'
+      channel:
+        - '<click:open_url:"https://google.com">'
+        - '<hover:show_text:"I am chatting in the %channel_name% channel<newline>Some new line">'
+        - '%chatchat_channel_prefix%'
+        - '</hover>'
+        - '</click>'
+      group:
+        - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line">'
+        - ' [%vault_group%]'
+        - '</hover>'
+      name:
+        - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line">'
+        - ' %player_displayname%'
+        - '</hover>'
+      divider:
+        - '<hover:show_text:"Cool diver tooltip here">'
+        - ' > '
+        - '</hover>'
+      message:
+        - '<message>'
+        - '<hover:show_text:"This forces everyone to have a ! on the end. Haha">'
+        - '!'
+        - '</hover>'
 
   staff: # user needs 'chatchat.format.staff' permission
     priority: 1
     parts:
-      - '<click:open_url:"https://google.com"><hover:show_text:"I am chatting in the %channel% channel<newline>Some new line">%chatchat_channel_prefix%</hover></click>'
-      - '<hover:show_text:"Hey look, i am staff<newline>Some new line">  [STAFF]</hover>'
-      - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line"> %player_displayname%</hover>'
-      - '<hover:show_text:"Cool diver tooltip here"> ></hover>'
-      - '<message>'
+      channel:
+        - '<click:open_url:"https://google.com">'
+        - '<hover:show_text:"I am chatting in the %channel_name% channel<newline>Some new line">'
+        - '%chatchat_channel_prefix%'
+        - '</hover>'
+        - '</click>'
+      prefix:
+        - '<hover:show_text:"Hey look, i am staff<newline>Some new line">'
+        - ' [STAFF]'
+        - '</hover>'
+      name:
+        - '<hover:show_text:"Hey look, i am in the %vault_group% permission group.<newline>Some new line">'
+        - ' %player_displayname%'
+        - '</hover>'
+      message-and-divider:
+        - '<hover:show_text:"Cool diver tooltip here"> ></hover>'
+        - '<message>'

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -7,7 +7,7 @@ sender-format:
     separator:
       - ' <color:#40c9ff>-> '
     recipient:
-      - '<gray>%recipient_player_name%'
+      - '<gray><recipient:player_name>'
     message:
       - ' <#e81cff>» <white><message>'
 # The format to send to the recipient of a private message
@@ -32,7 +32,7 @@ social-spy-format:
     separator:
       - ' <#40c9ff>-> '
     recipient:
-      - '<gray>%recipient_player_name%'
+      - '<gray><recipient:player_name>'
     message:
       - ' <#e81cff>» <white><message>'
 

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -2,16 +2,39 @@
 # All formats can be formatted using MiniMessage: https://docs.adventure.kyori.net/minimessage/index.html
 sender-format:
   parts:
-    - '<gray>you <color:#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>'
+    sender:
+      - '<gray>you'
+    separator:
+      - ' <color:#40c9ff>-> '
+    recipient:
+      - '<gray>%recipient_player_name%'
+    message:
+      - ' <#e81cff>» <white><message>'
 # The format to send to the recipient of a private message
 recipient-format:
   parts:
-    - '<gray>%player_name% <#40c9ff>-> <gray>you <#e81cff>» <white><message>'
+    sender:
+      - '<gray>%player_name%'
+    separator:
+      - ' <#40c9ff>-> '
+    recipient:
+      - '<gray>you'
+    message:
+      - ' <#e81cff>» <white><message>'
 
 # The format to send to any players with socialspy enabled
 social-spy-format:
   parts:
-    - '<gray>(spy) %player_name% <#40c9ff>-> <gray>%recipient_player_name% <#e81cff>» <white><message>'
+    prefix:
+      - '<gray>(spy) '
+    sender:
+      - '%player_name%'
+    separator:
+      - ' <#40c9ff>-> '
+    recipient:
+      - '<gray>%recipient_player_name%'
+    message:
+      - ' <#e81cff>» <white><message>'
 
 # The format that the <item> placeholder will use in chat. Needs to contain <item>.
 # Another available internal placeholder is <amount>.
@@ -26,7 +49,11 @@ mention-prefix: '@'
 
 # The format to use for individual player mentions
 mention-format:
-  parts: ['<yellow>@%player_name%']
+  parts:
+    name:
+      - '<hover:show_text:"<gold>This is a mention!">'
+      - '<yellow>@%player_name%'
+      - '</hover>'
 
 # The format to use for @channel/@here/@everyone
 channel-mention-format: '<yellow>'


### PR DESCRIPTION
- Upgraded adventure platform to 4.1.0 from 4.0.1
- Fixed default internal format using %message% instead of <message> (Closes #59 )
- Default formats are now LinkedHashMap
- Improved default files
- Switched from a shitty %recipient_PAPI-PLACEHOLDER% parser to a nice <recipient:PAPI-PLACEHOLDER> minimessage tag
- Added more internal placeholders: `%chatchat_channel_message_prefix%`, `%chatchat_social_spy_enabled%`, `%chatchat_private_messages_enabled%` and `%chatchat_private_messages_recipient%`. This means full parity with DeluxeTag's placeholders.
- Allowed some placeholders to work for a null target as well. They'll just be parsed for the ConsoleUser.

Note: \<recipient\> is also a placeholder and will return the player's name.