### PR TITLE
Fixes 1.13+ support.

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/exception/ChatChatException.java
+++ b/api/src/main/java/at/helpch/chatchat/api/exception/ChatChatException.java
@@ -1,0 +1,7 @@
+package at.helpch.chatchat.api.exception;
+
+public final class ChatChatException extends RuntimeException {
+    public ChatChatException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/at/helpch/chatchat/api/hook/Hook.java
+++ b/api/src/main/java/at/helpch/chatchat/api/hook/Hook.java
@@ -1,6 +1,5 @@
 package at.helpch.chatchat.api.hook;
 
-import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +8,14 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface Hook {
     /**
-     * @return the plugin that this hook depends on
+     * @return true if ChatChat should register the hook or false otherwise.
      */
-    @NotNull Optional<@NotNull List<String>> dependency();
+    boolean register();
+
+    /**
+     * @return the name of the hook. this is only going to be used for display purposes and not for anything internally.
+     */
+    @NotNull Optional<@NotNull String> name();
 
     /**
      * Enable the hook.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ towny = "0.98.1.3"
 discordsrv = "1.25.1"
 supervanish = "6.2.6-4"
 bstats = "3.0.0"
+essentials = "2.19.4"
 
 [libraries]
 # Minecraft
@@ -32,3 +33,4 @@ towny = { module = "com.palmergames.bukkit.towny:towny", version.ref = "towny" }
 discordsrv = { module = "com.discordsrv:discordsrv", version.ref = "discordsrv" }
 supervanish = { module = "com.github.LeonMangler:SuperVanish", version.ref = "supervanish" }
 bstats = { module = "org.bstats:bstats-bukkit", version.ref = "bstats" }
+essentials = { module = "net.essentialsx:EssentialsX", version.ref="essentials" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -17,6 +17,8 @@ repositories {
     maven("https://nexus.scarsz.me/content/groups/public")
     // supervanish
     maven("https://jitpack.io")
+    // essentialsx
+    maven("https://repo.essentialsx.net/releases/")
 }
 
 dependencies {
@@ -27,6 +29,7 @@ dependencies {
     implementation(libs.adventure.minimessage)
     implementation(libs.configurate)
     implementation(libs.bstats)
+    implementation(libs.essentials)
     implementation(libs.adventure.configurate)
 
     compileOnly(libs.spigot)

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/HookManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/HookManager.java
@@ -5,6 +5,7 @@ import at.helpch.chatchat.api.hook.Hook;
 import at.helpch.chatchat.hooks.dsrv.ChatChatDsrvHook;
 import at.helpch.chatchat.hooks.towny.ChatChatTownyHook;
 import at.helpch.chatchat.api.hook.VanishHook;
+import at.helpch.chatchat.hooks.vanish.EssentialsVanishHook;
 import at.helpch.chatchat.hooks.vanish.SuperVanishHook;
 import at.helpch.chatchat.hooks.vanish.VanillaVanishHook;
 
@@ -18,6 +19,7 @@ public final class HookManager {
         ChatChatDsrvHook::new,
         ChatChatTownyHook::new,
         VanillaVanishHook::new,
+        EssentialsVanishHook::new,
         SuperVanishHook::new
     );
     private final ChatChatPlugin plugin;

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/HookManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/HookManager.java
@@ -7,15 +7,8 @@ import at.helpch.chatchat.hooks.towny.ChatChatTownyHook;
 import at.helpch.chatchat.api.hook.VanishHook;
 import at.helpch.chatchat.hooks.vanish.SuperVanishHook;
 import at.helpch.chatchat.hooks.vanish.VanillaVanishHook;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -45,18 +38,7 @@ public final class HookManager {
         for (final var constructor : constructors) {
             final var hook = constructor.apply(plugin);
 
-            final @Nullable List<Plugin> hookPlugins = hook.dependency().isPresent()
-                ? hook.dependency().get().stream()
-                .map(Bukkit.getPluginManager()::getPlugin)
-                .filter(Objects::nonNull)
-                .filter(Plugin::isEnabled)
-                .collect(Collectors.toUnmodifiableList())
-                : Collections.emptyList();
-
-            if (hook.dependency().isPresent() && hookPlugins.isEmpty()) {
-                continue;
-            }
-
+            if (!hook.register()) return;
             hook.enable();
 
             if (hook instanceof VanishHook) {
@@ -65,9 +47,7 @@ public final class HookManager {
                 hooks.add(hook);
             }
 
-            if (!hookPlugins.isEmpty()) {
-                plugin.getLogger().info("Enabled " + hookPlugins.get(0).getName() + " hook.");
-            }
+            if (hook.name().isPresent()) plugin.getLogger().info("Enabled the " + hook.name().get() + " hook.");
         }
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/ChatChatDsrvHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/ChatChatDsrvHook.java
@@ -3,12 +3,12 @@ package at.helpch.chatchat.hooks.dsrv;
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.hook.Hook;
 import github.scarsz.discordsrv.DiscordSRV;
-import java.util.List;
 import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 public final class ChatChatDsrvHook implements Hook {
+    private static final String DISCORD_SRV = "DiscordSRV";
 
     private final ChatChatPlugin plugin;
 
@@ -17,8 +17,14 @@ public final class ChatChatDsrvHook implements Hook {
     }
 
     @Override
-    public @NotNull Optional<@NotNull List<String>> dependency() {
-        return Optional.of(List.of("DiscordSRV"));
+    public boolean register() {
+        return Bukkit.getPluginManager().isPluginEnabled(DISCORD_SRV);
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull String> name() {
+        if (register()) return Optional.of(DISCORD_SRV);
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/towny/ChatChatTownyHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/towny/ChatChatTownyHook.java
@@ -2,11 +2,13 @@ package at.helpch.chatchat.hooks.towny;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.hook.Hook;
-import java.util.List;
 import java.util.Optional;
+import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 public class ChatChatTownyHook implements Hook {
+
+    private static final String TOWNY = "Towny";
 
     private final ChatChatPlugin plugin;
 
@@ -15,8 +17,14 @@ public class ChatChatTownyHook implements Hook {
     }
 
     @Override
-    public @NotNull Optional<@NotNull List<String>> dependency() {
-        return Optional.of(List.of("Towny"));
+    public boolean register() {
+        return Bukkit.getPluginManager().isPluginEnabled(TOWNY);
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull String> name() {
+        if (register()) return Optional.of(TOWNY);
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/EssentialsVanishHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/EssentialsVanishHook.java
@@ -1,0 +1,49 @@
+package at.helpch.chatchat.hooks.vanish;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
+import at.helpch.chatchat.api.hook.VanishHook;
+import at.helpch.chatchat.listener.EssentialsVanishListener;
+import java.util.Optional;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * <p>
+ *     Vanish Hook that uses Essentials' implementation of player hiding
+ *    {@link net.ess3.api.IUser#setVanished(boolean) IUser#setVanished} to check if player is vanished.
+ * </p>
+ * <p>
+ *     Some plugins that this is known to work with: EssentialsX
+ * </p>
+ */
+public class EssentialsVanishHook extends VanishHook {
+
+    private static final String ESSENTIALS = "Essentials";
+
+    private final ChatChatPlugin plugin;
+
+    public EssentialsVanishHook(@NotNull final ChatChatPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean register() {
+        return Bukkit.getPluginManager().isPluginEnabled(ESSENTIALS);
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull String> name() {
+        return Optional.of(ESSENTIALS);
+    }
+
+    @Override
+    public void enable() {
+        plugin.getServer().getPluginManager().registerEvents(new EssentialsVanishListener(plugin), plugin);
+    }
+
+    @Override
+    public boolean canSee(@NotNull final ChatUser user, @NotNull final ChatUser target) {
+        return user.player().canSee(target.player());
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/SuperVanishHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/SuperVanishHook.java
@@ -5,8 +5,8 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.hook.VanishHook;
 import at.helpch.chatchat.listener.SuperVanishListener;
 import de.myzelyam.api.vanish.VanishAPI;
-import java.util.List;
 import java.util.Optional;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,6 +21,9 @@ import org.jetbrains.annotations.NotNull;
  */
 public class SuperVanishHook extends VanishHook {
 
+    private static final String SUPER_VANISH = "SuperVanish";
+    private static final String PREMIUM_VANISH = "PremiumVanish";
+
     private final ChatChatPlugin plugin;
 
     public SuperVanishHook(@NotNull final ChatChatPlugin plugin) {
@@ -28,8 +31,16 @@ public class SuperVanishHook extends VanishHook {
     }
 
     @Override
-    public @NotNull Optional<@NotNull List<String>> dependency() {
-        return Optional.of(List.of("SuperVanish", "PremiumVanish"));
+    public boolean register() {
+        return Bukkit.getPluginManager().isPluginEnabled(SUPER_VANISH) ||
+            Bukkit.getPluginManager().isPluginEnabled(PREMIUM_VANISH);
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull String> name() {
+        if (Bukkit.getPluginManager().isPluginEnabled(SUPER_VANISH)) return Optional.of(SUPER_VANISH);
+        if (Bukkit.getPluginManager().isPluginEnabled(PREMIUM_VANISH)) return Optional.of(PREMIUM_VANISH);
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/VanillaVanishHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/VanillaVanishHook.java
@@ -4,7 +4,7 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.hook.VanishHook;
 import at.helpch.chatchat.listener.VanillaVanishListener;
-import java.util.List;
+import at.helpch.chatchat.util.VersionHelper;
 import java.util.Optional;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -28,7 +28,12 @@ public class VanillaVanishHook extends VanishHook {
     }
 
     @Override
-    public @NotNull Optional<@NotNull List<String>> dependency() {
+    public boolean register() {
+        return VersionHelper.CURRENT_VERSION >= VersionHelper.V1_19_0;
+    }
+
+    @Override
+    public @NotNull Optional<@NotNull String> name() {
         return Optional.empty();
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/listener/EssentialsVanishListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/EssentialsVanishListener.java
@@ -1,0 +1,38 @@
+package at.helpch.chatchat.listener;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
+import net.ess3.api.events.VanishStatusChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+
+public class EssentialsVanishListener implements Listener {
+
+    private final ChatChatPlugin plugin;
+
+    public EssentialsVanishListener(@NotNull final ChatChatPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    private void onVanish(@NotNull final VanishStatusChangeEvent event) {
+        final var chatUser = (ChatUser) plugin.usersHolder().getUser(event.getAffected().getBase());
+
+        final var lastMessaged = chatUser.lastMessagedUser();
+        if (lastMessaged.isEmpty()) {
+            return;
+        }
+
+        if (!lastMessaged.get().uuid().equals(event.getAffected().getUUID())) {
+            return;
+        }
+
+        if (chatUser.canSee(lastMessaged.get())) {
+            return;
+        }
+
+        chatUser.lastMessagedUser(null);
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/ItemUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ItemUtils.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -42,7 +43,12 @@ public final class ItemUtils {
             ? MessageUtils.parseToMiniMessage(itemFormatInfo, itemPlaceholder, amountPlaceholder)
             : null;
 
-        if (item.getType().isAir() || !item.hasItemMeta()) {
+        if (item.getType() == Material.AIR ||
+            item.getType() == Material.CAVE_AIR ||
+            item.getType() == Material.VOID_AIR ||
+            item.getType() == Material.LEGACY_AIR ||
+            !item.hasItemMeta()
+        ) {
             return Placeholder.component(
                 "item",
                 MessageUtils.parseToMiniMessage(itemFormat, itemPlaceholder, amountPlaceholder).hoverEvent(hoverInfoComponent));

--- a/plugin/src/main/java/at/helpch/chatchat/util/VersionHelper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/VersionHelper.java
@@ -1,0 +1,81 @@
+package at.helpch.chatchat.util;
+
+import at.helpch.chatchat.api.exception.ChatChatException;
+import com.google.common.primitives.Ints;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Class for detecting server version for legacy support :(
+ * @author Matt
+ */
+public final class VersionHelper {
+
+    public static final String NMS_VERSION = getNmsVersion();
+
+    public static final int CURRENT_VERSION = getCurrentVersion();
+
+    public static final boolean IS_PAPER = checkPaper();
+
+    public static final int V1_13_2 = 1132;
+    public static final int V1_14_4 = 1144;
+    public static final int V1_15_2 = 1152;
+    public static final int V1_16_5 = 1165;
+    public static final int V1_17_1 = 1171;
+    public static final int V1_18_2 = 1182;
+    public static final int V1_19_0 = 1190;
+
+    /**
+     * Check if the server has access to the Paper API
+     * Taken from <a href="https://github.com/PaperMC/PaperLib">PaperLib</a>
+     *
+     * @return True if on Paper server (or forks), false anything else
+     */
+    private static boolean checkPaper() {
+        try {
+            Class.forName("com.destroystokyo.paper.PaperConfig");
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Gets the current server version
+     *
+     * @return A protocol like number representing the version, for example 1.16.5 - 1165
+     */
+    private static int getCurrentVersion() {
+        // No need to cache since will only run once
+        final Matcher matcher = Pattern.compile("(?<version>\\d+\\.\\d+)(?<patch>\\.\\d+)?").matcher(Bukkit.getBukkitVersion());
+
+        final StringBuilder stringBuilder = new StringBuilder();
+        if (matcher.find()) {
+            stringBuilder.append(matcher.group("version").replace(".", ""));
+            final String patch = matcher.group("patch");
+            if (patch == null) stringBuilder.append("0");
+            else stringBuilder.append(patch.replace(".", ""));
+        }
+
+        //noinspection UnstableApiUsage
+        final Integer version = Ints.tryParse(stringBuilder.toString());
+
+        // Should never fail
+        if (version == null) throw new ChatChatException("Could not retrieve server version!");
+
+        return version;
+    }
+
+    private static String getNmsVersion() {
+        final String version = Bukkit.getServer().getClass().getPackage().getName();
+        return version.substring(version.lastIndexOf('.') + 1);
+    }
+
+    public static Class<?> craftClass(@NotNull final String name) throws ClassNotFoundException {
+        return Class.forName("org.bukkit.craftbukkit." + NMS_VERSION + "." + name);
+    }
+
+}


### PR DESCRIPTION
ChatChat was using some methods and events that were not available on all 1.13+ versions and was just throwing errors. This PR should fix most if not all of those.

- Fixed usage of PlayerHideEvent on versions older than 1.19
- Fixed usage of Material#isAir on versions older than 1.14
- Added a direct EssentialsX vanish hook