### PR TITLE
Messages sent in the default channel will be seen by everyone

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -51,6 +51,11 @@ public final class ChatChannel extends AbstractChannel {
 
     @Override
     public Set<User> targets(final @NotNull User source) {
+        if (plugin.configManager().channels().defaultChannel().equals(this.name()))
+            return plugin.usersHolder().users().stream()
+                .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
+                .collect(Collectors.toUnmodifiableSet());
+
         return plugin.usersHolder().users().stream().filter(user ->
                 !(user instanceof ChatUser) ||
                     ((ChatUser) user).player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + name()))


### PR DESCRIPTION
Currently, people can switch to the default channel with no problem, they can also send messages without any permissions being required but they won't see any messages sent in that channel, including their own.

I'm thinking if we should make it so the sender sees the message sent by them even if they don't have permission to see messages sent in that channel since right now someone could maybe accidentally or intentionally send a message in a channel and just not realize it was ever sent.

https://github.com/HelpChat/ChatChat/blob/0ad4db59553857c5349661decbd939662187fbc0/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java#L222