### PR TITLE
Added <papi> and <papi-rel> tags

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -69,7 +69,8 @@ public final class FormatUtils {
                     .map(part -> String.join("", part))
                     .collect(Collectors.joining())
             ),
-            Placeholder.component("message", message)
+            Placeholder.component("message", message),
+            PapiTagUtils.createPlaceholderAPITag(player)
         );
     }
 
@@ -92,6 +93,8 @@ public final class FormatUtils {
                 )
             ),
             Placeholder.component("message", message),
+            PapiTagUtils.createPlaceholderAPITag(player),
+            PapiTagUtils.createRelPlaceholderAPITag(player, recipient),
             recipientTagResolver(recipient)
         );
     }

--- a/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
@@ -1,7 +1,6 @@
 package at.helpch.chatchat.util;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.common.collect.ImmutableMap;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -9,38 +8,39 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 
 public final class Kyorifier {
-    private static final Map<Character, String> COLOURS = new HashMap<>(15);
-    private static final Map<Character, String> FORMATTERS = new HashMap<>(6);
-    private static final Pattern LEGACY_HEX_COLORS_PATTERN = Pattern.compile(
-        "&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
+    private static final ImmutableMap<Character, String> COLOURS = new ImmutableMap.Builder<Character, String>()
+        .put('0', NamedTextColor.BLACK.toString())
+        .put('0', NamedTextColor.BLACK.toString())
+        .put('1', NamedTextColor.DARK_BLUE.toString())
+        .put('2', NamedTextColor.DARK_GREEN.toString())
+        .put('3', NamedTextColor.DARK_AQUA.toString())
+        .put('4', NamedTextColor.DARK_RED.toString())
+        .put('5', NamedTextColor.DARK_PURPLE.toString())
+        .put('6', NamedTextColor.GOLD.toString())
+        .put('7', NamedTextColor.GRAY.toString())
+        .put('8', NamedTextColor.DARK_GRAY.toString())
+        .put('9', NamedTextColor.BLUE.toString())
+        .put('a', NamedTextColor.GREEN.toString())
+        .put('b', NamedTextColor.AQUA.toString())
+        .put('c', NamedTextColor.RED.toString())
+        .put('d', NamedTextColor.LIGHT_PURPLE.toString())
+        .put('e', NamedTextColor.YELLOW.toString())
+        .put('f', NamedTextColor.WHITE.toString())
+        .build();
 
-    static {
-        COLOURS.put('0', NamedTextColor.BLACK.toString());
-        COLOURS.put('1', NamedTextColor.DARK_BLUE.toString());
-        COLOURS.put('2', NamedTextColor.DARK_GREEN.toString());
-        COLOURS.put('3', NamedTextColor.DARK_AQUA.toString());
-        COLOURS.put('4', NamedTextColor.DARK_RED.toString());
-        COLOURS.put('5', NamedTextColor.DARK_PURPLE.toString());
-        COLOURS.put('6', NamedTextColor.GOLD.toString());
-        COLOURS.put('7', NamedTextColor.GRAY.toString());
-        COLOURS.put('8', NamedTextColor.DARK_GRAY.toString());
-        COLOURS.put('9', NamedTextColor.BLUE.toString());
-        COLOURS.put('a', NamedTextColor.GREEN.toString());
-        COLOURS.put('b', NamedTextColor.AQUA.toString());
-        COLOURS.put('c', NamedTextColor.RED.toString());
-        COLOURS.put('d', NamedTextColor.LIGHT_PURPLE.toString());
-        COLOURS.put('e', NamedTextColor.YELLOW.toString());
-        COLOURS.put('f', NamedTextColor.WHITE.toString());
-
-        FORMATTERS.put('k', TextDecoration.OBFUSCATED.toString());
-        FORMATTERS.put('l', TextDecoration.BOLD.toString());
-        FORMATTERS.put('m', TextDecoration.STRIKETHROUGH.toString());
-        FORMATTERS.put('n', TextDecoration.UNDERLINED.toString());
-        FORMATTERS.put('o', TextDecoration.ITALIC.toString());
+    private static final ImmutableMap<Character, String> FORMATTERS = new ImmutableMap.Builder<Character, String>()
+        .put('k', TextDecoration.OBFUSCATED.toString())
+        .put('l', TextDecoration.BOLD.toString())
+        .put('m', TextDecoration.STRIKETHROUGH.toString())
+        .put('n', TextDecoration.UNDERLINED.toString())
+        .put('o', TextDecoration.ITALIC.toString())
         // The <reset> tag is never placed. Instead, we close existent tags. So it doesn't matter what name we give
         // here. Also, there isn't a way to get the name of the reset tag from adventure.
-        FORMATTERS.put('r', "reset");
-    }
+        .put('r', "reset")
+        .build();
+
+    private static final Pattern LEGACY_HEX_COLORS_PATTERN = Pattern.compile(
+        "&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
 
     private static StringBuilder closeAll(Stack<String> activeFormatters) {
         final var out = new StringBuilder();

--- a/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 
 public final class Kyorifier {
     private static final Map<Character, String> COLOURS = new HashMap<>(15);
@@ -12,28 +14,30 @@ public final class Kyorifier {
     private static final Pattern pattern = Pattern.compile("&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
 
     static {
-        COLOURS.put('0', "black");
-        COLOURS.put('1', "dark_blue");
-        COLOURS.put('2', "dark_green");
-        COLOURS.put('3', "dark_aqua");
-        COLOURS.put('4', "dark_red");
-        COLOURS.put('5', "dark_purple");
-        COLOURS.put('6', "gold");
-        COLOURS.put('7', "gray");
-        COLOURS.put('8', "dark_gray");
-        COLOURS.put('9', "blue");
-        COLOURS.put('a', "green");
-        COLOURS.put('b', "aqua");
-        COLOURS.put('c', "red");
-        COLOURS.put('d', "light_purple");
-        COLOURS.put('e', "yellow");
-        COLOURS.put('f', "white");
+        COLOURS.put('0', NamedTextColor.BLACK.toString());
+        COLOURS.put('1', NamedTextColor.DARK_BLUE.toString());
+        COLOURS.put('2', NamedTextColor.DARK_GREEN.toString());
+        COLOURS.put('3', NamedTextColor.DARK_AQUA.toString());
+        COLOURS.put('4', NamedTextColor.DARK_RED.toString());
+        COLOURS.put('5', NamedTextColor.DARK_PURPLE.toString());
+        COLOURS.put('6', NamedTextColor.GOLD.toString());
+        COLOURS.put('7', NamedTextColor.GRAY.toString());
+        COLOURS.put('8', NamedTextColor.DARK_GRAY.toString());
+        COLOURS.put('9', NamedTextColor.BLUE.toString());
+        COLOURS.put('a', NamedTextColor.GREEN.toString());
+        COLOURS.put('b', NamedTextColor.AQUA.toString());
+        COLOURS.put('c', NamedTextColor.RED.toString());
+        COLOURS.put('d', NamedTextColor.LIGHT_PURPLE.toString());
+        COLOURS.put('e', NamedTextColor.YELLOW.toString());
+        COLOURS.put('f', NamedTextColor.WHITE.toString());
 
-        FORMATTERS.put('k', "obfuscated");
-        FORMATTERS.put('l', "bold");
-        FORMATTERS.put('m', "strikethrough");
-        FORMATTERS.put('n', "underlined");
-        FORMATTERS.put('o', "italic");
+        FORMATTERS.put('k', TextDecoration.OBFUSCATED.toString());
+        FORMATTERS.put('l', TextDecoration.BOLD.toString());
+        FORMATTERS.put('m', TextDecoration.STRIKETHROUGH.toString());
+        FORMATTERS.put('n', TextDecoration.UNDERLINED.toString());
+        FORMATTERS.put('o', TextDecoration.ITALIC.toString());
+        // The <reset> tag is never placed. Instead, we close existent tags. So it doesn't matter what name we give
+        // here. Also, there isn't a way to get the name of the reset tag from adventure.
         FORMATTERS.put('r', "reset");
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
@@ -1,0 +1,71 @@
+package at.helpch.chatchat.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class Kyorifier {
+    private static final Map<Character, String> COLOURS = new HashMap<>(15);
+    private static final Map<Character, String> FORMATTERS = new HashMap<>(6);
+    private static final Pattern pattern = Pattern.compile("&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
+
+    static {
+        COLOURS.put('0', "black");
+        COLOURS.put('1', "dark_blue");
+        COLOURS.put('2', "dark_green");
+        COLOURS.put('3', "dark_aqua");
+        COLOURS.put('4', "dark_red");
+        COLOURS.put('5', "dark_purple");
+        COLOURS.put('6', "gold");
+        COLOURS.put('7', "gray");
+        COLOURS.put('8', "dark_gray");
+        COLOURS.put('9', "blue");
+        COLOURS.put('a', "green");
+        COLOURS.put('b', "aqua");
+        COLOURS.put('c', "red");
+        COLOURS.put('d', "light_purple");
+        COLOURS.put('e', "yellow");
+        COLOURS.put('f', "white");
+
+        FORMATTERS.put('k', "obfuscated");
+        FORMATTERS.put('l', "bold");
+        FORMATTERS.put('m', "strikethrough");
+        FORMATTERS.put('n', "underlined");
+        FORMATTERS.put('o', "italic");
+        FORMATTERS.put('r', "reset");
+    }
+
+    private static StringBuilder closeAll(Stack<String> activeFormatters) {
+        final var out = new StringBuilder();
+        while (!activeFormatters.isEmpty()) {
+            out.append("</").append(activeFormatters.pop()).append(">");
+        }
+        return out;
+    }
+
+    public static String kyorify(String input) {
+        final Stack<String> activeFormatters = new Stack<>();
+        return pattern.matcher(input.replace("§", "&")).replaceAll(result -> {
+            final Matcher matcher = (Matcher) result;
+            final var hex = matcher.group("hex");
+            final var code = matcher.group("code");
+            final var colour = hex == null ? COLOURS.get(code.charAt(0)) : "#" + hex.replace("&", "");
+
+            if (colour == null) {
+                final var formatter = FORMATTERS.get(code.charAt(0));
+                if (formatter.equals("reset")) {
+                    return closeAll(activeFormatters).toString();
+                }
+                activeFormatters.push(formatter);
+                return "<" + formatter + ">";
+            } else {
+                final var out = closeAll(activeFormatters);
+                out.append("<").append(colour).append(">");
+
+                return out.toString();
+            }
+        });
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/Kyorifier.java
@@ -11,7 +11,8 @@ import net.kyori.adventure.text.format.TextDecoration;
 public final class Kyorifier {
     private static final Map<Character, String> COLOURS = new HashMap<>(15);
     private static final Map<Character, String> FORMATTERS = new HashMap<>(6);
-    private static final Pattern pattern = Pattern.compile("&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
+    private static final Pattern LEGACY_HEX_COLORS_PATTERN = Pattern.compile(
+        "&(?<code>[\\da-fk-or])|[&{\\[<]?[#x](?<hex>(&?[A-Fa-f\\d]){6})[}\\]>]?");
 
     static {
         COLOURS.put('0', NamedTextColor.BLACK.toString());
@@ -51,7 +52,7 @@ public final class Kyorifier {
 
     public static String kyorify(String input) {
         final Stack<String> activeFormatters = new Stack<>();
-        return pattern.matcher(input.replace("§", "&")).replaceAll(result -> {
+        return LEGACY_HEX_COLORS_PATTERN.matcher(input.replace("§", "&")).replaceAll(result -> {
             final Matcher matcher = (Matcher) result;
             final var hex = matcher.group("hex");
             final var code = matcher.group("code");

--- a/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
@@ -1,0 +1,106 @@
+package at.helpch.chatchat.util;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public final class PapiTagUtils {
+
+    private PapiTagUtils() {
+        throw new AssertionError("Util classes are not to be instantiated!");
+    }
+
+    public static @NotNull TagResolver createPlaceholderAPITag(final @NotNull Player player) {
+        return TagResolver.resolver("papi", (argumentQueue, context) -> {
+            if (!argumentQueue.hasNext()) {
+                return null;
+            }
+
+            final String next = argumentQueue.pop().value().toLowerCase(Locale.ROOT);
+            if (!argumentQueue.hasNext()) {
+                return null;
+            }
+
+            final boolean inserting;
+            switch (next) {
+                case "closing":
+                    inserting = false;
+                    break;
+                case "inserting":
+                    inserting = true;
+                    break;
+                default:
+                    return null;
+            }
+
+            final var arguments = new ArrayList<String>();
+            while (argumentQueue.hasNext()) {
+                arguments.add(argumentQueue.pop().value());
+            }
+
+            final var placeholder = String.join(":", arguments);
+            if (placeholder.isBlank() || !placeholder.contains("_")) {
+                return null;
+            }
+
+            final var parsedPlaceholder = PlaceholderAPI.setPlaceholders(player, '%' + placeholder + '%');
+            final var kyorifiedPlaceholder = Kyorifier.kyorify(parsedPlaceholder);
+            final var componentPlaceholder = MessageUtils.parseToMiniMessage(kyorifiedPlaceholder);
+
+            return inserting ? Tag.inserting(componentPlaceholder) : Tag.selfClosingInserting(componentPlaceholder);
+        });
+    }
+
+    public static @NotNull TagResolver createRelPlaceholderAPITag(
+        final @NotNull Player player,
+        final @NotNull Player target
+    ) {
+        return TagResolver.resolver("papi-rel", (argumentQueue, context) -> {
+            if (!argumentQueue.hasNext()) {
+                return null;
+            }
+
+            final String next = argumentQueue.pop().value().toLowerCase(Locale.ROOT);
+            if (!argumentQueue.hasNext()) {
+                return null;
+            }
+
+            final boolean inserting;
+            switch (next) {
+                case "closing":
+                    inserting = false;
+                    break;
+                case "inserting":
+                    inserting = true;
+                    break;
+                default:
+                    return null;
+            }
+
+            final var arguments = new ArrayList<String>();
+            while (argumentQueue.hasNext()) {
+                arguments.add(argumentQueue.pop().value());
+            }
+
+            final var placeholder = String.join(":", arguments);
+            if (placeholder.isBlank() || !placeholder.contains("_") ||
+                !placeholder.toLowerCase(Locale.ROOT).startsWith("rel_")) {
+                return null;
+            }
+
+            final var parsedPlaceholder = PlaceholderAPI.setRelationalPlaceholders(
+                player,
+                target,
+                '%' + placeholder + '%'
+            );
+            final var kyorifiedPlaceholder = Kyorifier.kyorify(parsedPlaceholder);
+            final var componentPlaceholder = MessageUtils.parseToMiniMessage(kyorifiedPlaceholder);
+
+            return inserting ? Tag.inserting(componentPlaceholder) : Tag.selfClosingInserting(componentPlaceholder);
+        });
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
@@ -26,18 +26,27 @@ public final class PapiTagUtils {
             }
 
             final boolean inserting;
+            final boolean append;
             switch (next) {
                 case "closing":
                     inserting = false;
+                    append = false;
                     break;
                 case "inserting":
                     inserting = true;
+                    append = false;
                     break;
                 default:
-                    return null;
+                    inserting = false;
+                    append = true;
+                    break;
             }
 
             final var arguments = new ArrayList<String>();
+            if (append) {
+                arguments.add(next);
+            }
+
             while (argumentQueue.hasNext()) {
                 arguments.add(argumentQueue.pop().value());
             }


### PR DESCRIPTION
This adds 2 new tags that can be used in formats. These tags have 1 argument which can be either `closing` or `inserting`.

<b>How it works:</b>
Let's say we have a essentials nickname `&3Blitz`, and a format that looks like this:
```yml
parts:
  name:
  - '<white>TEST <papi:closing:essentials_nickname>: <message>'
```

In this format, the output in chat when sending a message `HELLOOO` will be something like this: 
![image](https://user-images.githubusercontent.com/52609756/183308203-44b2483f-f888-42b7-8d5f-bd629501a565.png)

But now if we change the `closing` argument with `inserting`, it will look like this:
![image](https://user-images.githubusercontent.com/52609756/183308212-34775fed-6ec0-4b34-9b42-e9043f66306a.png)

It works the same with the `<papi-rel>` tag but that one is for relational placeholders.

I am looking for feedback on this! 
<b>A few ideas:</b>
- We could add an extra argument for kyorify and remove the support for `%placeholder%` placeholders. What do you guys think about that? 
- Currently the `closing` and `inserting` tags are required. We could just make it so if none of them is selected it defaults to one of them?