### PR TITLE
Add a /ignore command

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
+++ b/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
@@ -5,6 +5,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 public interface ChatUser extends User {
 

--- a/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
+++ b/api/src/main/java/at/helpch/chatchat/api/ChatUser.java
@@ -5,8 +5,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 public interface ChatUser extends User {
 
@@ -23,4 +21,5 @@ public interface ChatUser extends User {
     void socialSpy(final boolean enable);
 
     boolean socialSpy();
+
 }

--- a/api/src/main/java/at/helpch/chatchat/api/User.java
+++ b/api/src/main/java/at/helpch/chatchat/api/User.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identified;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
 import java.util.UUID;
 
 public interface User extends ForwardingAudience.Single, Identified {
@@ -19,4 +20,12 @@ public interface User extends ForwardingAudience.Single, Identified {
     @NotNull UUID uuid();
 
     boolean canSee(@NotNull final User target);
+
+    @NotNull Set<UUID> ignoredUsers();
+
+    void ignoredUsers(@NotNull final Set<UUID> users);
+
+    void ignoreUser(@NotNull final User user);
+
+    void unignoreUser(@NotNull final User user);
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -66,6 +66,16 @@ bukkit {
             default = "op"
         }
 
+        permission("chatchat.ignore") {
+            description = "Permission to use /ignore to toggle ignoring a user"
+            default = "op"
+        }
+
+        permission("chatchat.ignore.bypass") {
+            description = "Bypass being ignored."
+            default = "op"
+        }
+
         permission("chatchat.utf") {
             description = "Send any char in chat"
             default = "op"

--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -130,6 +130,7 @@ public final class ChatChatPlugin extends JavaPlugin {
 
         List.of(
                 new MainCommand(),
+                new IgnoreCommand(this),
                 new ReloadCommand(this),
                 new WhisperCommand(this, false),
                 new ReplyCommand(this, new WhisperCommand(this, true)),

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -52,27 +52,26 @@ public final class ChatChannel extends AbstractChannel {
 
     @Override
     public Set<User> targets(final @NotNull User source) {
+
+        final Predicate<User> filterIgnores = user -> {
+            // console can't be ignored
+            if (source instanceof ConsoleUser) return true;
+            return !user.ignoredUsers().contains(source.uuid()) ||
+                ((ChatUser) source).player().hasPermission(IgnoreCommand.IGNORE_BYPASS_PERMISSION);
+        };
+
         if (plugin.configManager().channels().defaultChannel().equals(this.name()))
             return plugin.usersHolder().users().stream()
                 .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
-                .filter(filterIgnores(source))
+                .filter(filterIgnores)
                 .collect(Collectors.toUnmodifiableSet());
 
         return plugin.usersHolder().users().stream().filter(user ->
                 !(user instanceof ChatUser) ||
                     ((ChatUser) user).player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + name()))
             .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
-            .filter(filterIgnores(source))
+            .filter(filterIgnores)
             .collect(Collectors.toUnmodifiableSet());
-    }
-
-    private Predicate<User> filterIgnores(final @NotNull User source) {
-        return user -> {
-            // console can't be ignored
-            if (source instanceof ConsoleUser) return true;
-            return !user.ignoredUsers().contains(source.uuid()) ||
-                ((ChatUser) source).player().hasPermission(IgnoreCommand.IGNORE_BYPASS_PERMISSION);
-        };
     }
 
 }

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -3,15 +3,16 @@ package at.helpch.chatchat.channel;
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.User;
+import at.helpch.chatchat.command.IgnoreCommand;
 import at.helpch.chatchat.config.DefaultConfigObjects;
+import at.helpch.chatchat.user.ConsoleUser;
 import at.helpch.chatchat.util.ChannelUtils;
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @ConfigSerializable
@@ -20,11 +21,11 @@ public final class ChatChannel extends AbstractChannel {
     private static ChatChannel defaultChannel = DefaultConfigObjects.createDefaultChannel();
 
     public ChatChannel(
-            @NotNull final String name,
-            @NotNull final String messagePrefix,
-            @NotNull final List<String> toggleCommands,
-            @NotNull final String channelPrefix,
-            final int radius) {
+        @NotNull final String name,
+        @NotNull final String messagePrefix,
+        @NotNull final List<String> toggleCommands,
+        @NotNull final String channelPrefix,
+        final int radius) {
         super(name, messagePrefix, toggleCommands, channelPrefix, radius);
     }
 
@@ -41,12 +42,12 @@ public final class ChatChannel extends AbstractChannel {
     @Override
     public String toString() {
         return "ChatChannel{" +
-                "name=" + name() +
-                ", messagePrefix='" + messagePrefix() + '\'' +
-                ", toggleCommands='" + commandNames() + '\'' +
-                ", channelPrefix='" + channelPrefix() + '\'' +
-                ", radius='" + radius() +
-                '}';
+            "name=" + name() +
+            ", messagePrefix='" + messagePrefix() + '\'' +
+            ", toggleCommands='" + commandNames() + '\'' +
+            ", channelPrefix='" + channelPrefix() + '\'' +
+            ", radius='" + radius() +
+            '}';
     }
 
     @Override
@@ -54,12 +55,24 @@ public final class ChatChannel extends AbstractChannel {
         if (plugin.configManager().channels().defaultChannel().equals(this.name()))
             return plugin.usersHolder().users().stream()
                 .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
+                .filter(filterIgnores(source))
                 .collect(Collectors.toUnmodifiableSet());
 
         return plugin.usersHolder().users().stream().filter(user ->
                 !(user instanceof ChatUser) ||
                     ((ChatUser) user).player().hasPermission(ChannelUtils.SEE_CHANNEL_PERMISSION + name()))
-                .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
-                .collect(Collectors.toUnmodifiableSet());
+            .filter(user -> ChannelUtils.isTargetWithinRadius(source, user, radius()))
+            .filter(filterIgnores(source))
+            .collect(Collectors.toUnmodifiableSet());
     }
+
+    private Predicate<User> filterIgnores(final @NotNull User source) {
+        return user -> {
+            // console can't be ignored
+            if (source instanceof ConsoleUser) return true;
+            return !user.ignoredUsers().contains(source.uuid()) ||
+                ((ChatUser) source).player().hasPermission(IgnoreCommand.IGNORE_BYPASS_PERMISSION);
+        };
+    }
+
 }

--- a/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
+++ b/plugin/src/main/java/at/helpch/chatchat/channel/ChatChannel.java
@@ -5,7 +5,6 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.User;
 import at.helpch.chatchat.command.IgnoreCommand;
 import at.helpch.chatchat.config.DefaultConfigObjects;
-import at.helpch.chatchat.user.ConsoleUser;
 import at.helpch.chatchat.util.ChannelUtils;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -53,12 +52,8 @@ public final class ChatChannel extends AbstractChannel {
     @Override
     public Set<User> targets(final @NotNull User source) {
 
-        final Predicate<User> filterIgnores = user -> {
-            // console can't be ignored
-            if (source instanceof ConsoleUser) return true;
-            return !user.ignoredUsers().contains(source.uuid()) ||
-                ((ChatUser) source).player().hasPermission(IgnoreCommand.IGNORE_BYPASS_PERMISSION);
-        };
+        final Predicate<User> filterIgnores = user -> !user.ignoredUsers().contains(source.uuid()) ||
+            (source instanceof ChatUser && ((ChatUser) source).player().hasPermission(IgnoreCommand.IGNORE_BYPASS_PERMISSION));
 
         if (plugin.configManager().channels().defaultChannel().equals(this.name()))
             return plugin.usersHolder().users().stream()

--- a/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
@@ -1,0 +1,35 @@
+package at.helpch.chatchat.command;
+
+import at.helpch.chatchat.ChatChatPlugin;
+import at.helpch.chatchat.api.ChatUser;
+import dev.triumphteam.cmd.bukkit.annotation.Permission;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+
+@Command("ignore")
+public class IgnoreCommand extends BaseCommand {
+
+    final ChatChatPlugin plugin;
+    public final static String IGNORE_PERMISSION = "chatchat.ignore";
+
+    public IgnoreCommand(final ChatChatPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Permission(IGNORE_PERMISSION)
+    @Default
+    public void ignore(ChatUser sender, ChatUser target) {
+        final var ignored = sender.ignoredUsers().contains(target.uuid());
+
+        final var messageHolder = plugin.configManager().messages();
+        final var message = ignored ? messageHolder.unignoredPlayer() : messageHolder.ignoredPlayer();
+
+        if (ignored) sender.unignoreUser(target);
+        else sender.ignoreUser(target);
+
+        sender.sendMessage(message
+            .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.player().getDisplayName())));
+    }
+
+}

--- a/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
@@ -10,7 +10,7 @@ import dev.triumphteam.cmd.core.annotation.Default;
 @Command("ignore")
 public class IgnoreCommand extends BaseCommand {
 
-    final ChatChatPlugin plugin;
+    private final ChatChatPlugin plugin;
     private final static String IGNORE_PERMISSION = "chatchat.ignore";
     public static final String IGNORE_BYPASS_PERMISSION = IgnoreCommand.IGNORE_PERMISSION + ".bypass";
 
@@ -26,8 +26,11 @@ public class IgnoreCommand extends BaseCommand {
         final var messageHolder = plugin.configManager().messages();
         final var message = ignored ? messageHolder.unignoredPlayer() : messageHolder.ignoredPlayer();
 
-        if (ignored) sender.unignoreUser(target);
-        else sender.ignoreUser(target);
+        if (ignored) {
+            sender.unignoreUser(target);
+        } else {
+            sender.ignoreUser(target);
+        }
 
         sender.sendMessage(message
             .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.player().getDisplayName())));

--- a/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
@@ -11,7 +11,8 @@ import dev.triumphteam.cmd.core.annotation.Default;
 public class IgnoreCommand extends BaseCommand {
 
     final ChatChatPlugin plugin;
-    public final static String IGNORE_PERMISSION = "chatchat.ignore";
+    private final static String IGNORE_PERMISSION = "chatchat.ignore";
+    public static final String IGNORE_BYPASS_PERMISSION = IgnoreCommand.IGNORE_PERMISSION + ".bypass";
 
     public IgnoreCommand(final ChatChatPlugin plugin) {
         this.plugin = plugin;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holders/MessagesHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holders/MessagesHolder.java
@@ -1,12 +1,12 @@
 package at.helpch.chatchat.config.holders;
 
-import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
-import static net.kyori.adventure.text.format.NamedTextColor.RED;
-
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
 
 // configurate requires non-final fields
 @SuppressWarnings("FieldMayBeFinal")
@@ -27,9 +27,12 @@ public final class MessagesHolder {
     private Component privateMessagesDisabled = text("Your private messages have been disabled!", RED);
     private Component cantMessageYourself = text("You can't message yourself!", RED);
     private Component emptyMessage = text("You can't send an empty message!", RED);
-    private Component specialCharactersNoPermission = text("You do not have permission to use special characters!", RED);
+    private Component specialCharactersNoPermission = text("You do not have permission to use special characters!",
+        RED);
     private Component socialSpyEnabled = text("Social spy enabled", GREEN);
     private Component socialSpyDisabled = text("Social spy disabled", RED);
+    private Component ignoredPlayer = text("Successfully ignored <player>.", GREEN);
+    private Component unignoredPlayer = text("Successfully un-ignored <player>.", GREEN);
 
     // channel related
     private Component channelNoPermission = text("You do not have permission to use this channel", RED);
@@ -120,4 +123,13 @@ public final class MessagesHolder {
     public @NotNull Component noPermission() {
         return commandNoPermission;
     }
+
+    public @NotNull Component ignoredPlayer() {
+        return ignoredPlayer;
+    }
+
+    public @NotNull Component unignoredPlayer() {
+        return unignoredPlayer;
+    }
+
 }

--- a/plugin/src/main/java/at/helpch/chatchat/data/impl/gson/ChatUserAdapter.java
+++ b/plugin/src/main/java/at/helpch/chatchat/data/impl/gson/ChatUserAdapter.java
@@ -40,7 +40,9 @@ public final class ChatUserAdapter extends TypeAdapter<ChatUser> {
         out.value(value.socialSpy());
         out.name("ignored-users");
         out.beginArray();
-        for (UUID uuid : value.ignoredUsers()) out.value(uuid.toString());
+        for (UUID uuid : value.ignoredUsers()) {
+            out.value(uuid.toString());
+        }
         out.endArray();
 
         out.endObject();

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -34,8 +34,8 @@ public final class ChatUserImpl implements ChatUser {
     // TODO: 8/9/22 Remove unused field!
     private Format format;
     private boolean privateMessages = true;
-    private Set<UUID> ignoredUsers = new HashSet<>();
     private boolean socialSpy = false;
+    private Set<UUID> ignoredUsers = new HashSet<>();
 
     @Override
     public @NotNull Channel channel() {
@@ -81,6 +81,14 @@ public final class ChatUserImpl implements ChatUser {
     public void privateMessages(final boolean enabled) {
         this.privateMessages = enabled;
     }
+    public void socialSpy(final boolean enabled) {
+        socialSpy = enabled;
+    }
+
+    @Override
+    public boolean socialSpy() {
+        return socialSpy;
+    }
 
     @Override
     public @NotNull Set<UUID> ignoredUsers() {
@@ -100,15 +108,6 @@ public final class ChatUserImpl implements ChatUser {
     @Override
     public void unignoreUser(@NotNull User user) {
         ignoredUsers.remove(user.uuid());
-    }
-
-    public void socialSpy(final boolean enabled) {
-        socialSpy = enabled;
-    }
-
-    @Override
-    public boolean socialSpy() {
-        return socialSpy;
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -81,6 +81,8 @@ public final class ChatUserImpl implements ChatUser {
     public void privateMessages(final boolean enabled) {
         this.privateMessages = enabled;
     }
+
+    @Override
     public void socialSpy(final boolean enabled) {
         socialSpy = enabled;
     }

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -6,8 +6,11 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.Format;
 import at.helpch.chatchat.api.User;
 import at.helpch.chatchat.cache.ExpiringCache;
+
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.audience.Audience;
@@ -30,6 +33,7 @@ public final class ChatUserImpl implements ChatUser {
     private Channel channel;
     private Format format;
     private boolean privateMessages = true;
+    private Set<UUID> ignoredUsers = new HashSet<>();
 
     @Override
     public @NotNull Channel channel() {
@@ -74,6 +78,26 @@ public final class ChatUserImpl implements ChatUser {
     @Override
     public void privateMessages(final boolean enabled) {
         this.privateMessages = enabled;
+    }
+
+    @Override
+    public @NotNull Set<UUID> ignoredUsers() {
+        return ignoredUsers;
+    }
+
+    @Override
+    public void ignoredUsers(@NotNull Set<UUID> users) {
+        this.ignoredUsers = users;
+    }
+
+    @Override
+    public void ignoreUser(@NotNull User user) {
+        ignoredUsers.add(user.uuid());
+    }
+
+    @Override
+    public void unignoreUser(@NotNull User user) {
+        ignoredUsers.remove(user.uuid());
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
@@ -10,13 +10,15 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
 import java.util.UUID;
 
 public final class ConsoleUser implements User {
 
     public static final ConsoleUser INSTANCE = new ConsoleUser();
 
-    private ConsoleUser() {}
+    private ConsoleUser() {
+    }
 
     @Override
     public @NotNull Channel channel() {
@@ -24,7 +26,8 @@ public final class ConsoleUser implements User {
     }
 
     @Override
-    public void channel(@NotNull final Channel channel) {}
+    public void channel(@NotNull final Channel channel) {
+    }
 
     @Override
     public @NotNull Format format() {
@@ -32,7 +35,8 @@ public final class ConsoleUser implements User {
     }
 
     @Override
-    public void format(@NotNull final Format format) {}
+    public void format(@NotNull final Format format) {
+    }
 
     @Override
     public @NotNull UUID uuid() {
@@ -45,6 +49,23 @@ public final class ConsoleUser implements User {
     }
 
     @Override
+    public @NotNull Set<UUID> ignoredUsers() {
+        return Set.of();
+    }
+
+    @Override
+    public void ignoredUsers(@NotNull Set<UUID> users) {
+    }
+
+    @Override
+    public void ignoreUser(@NotNull User user) {
+    }
+
+    @Override
+    public void unignoreUser(@NotNull User user) {
+    }
+
+    @Override
     public @NotNull Audience audience() {
         return ChatChatPlugin.audiences().console();
     }
@@ -53,4 +74,5 @@ public final class ConsoleUser implements User {
     public @NotNull Identity identity() {
         return Identity.nil();
     }
+
 }

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -6,6 +6,7 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.MentionType;
 import at.helpch.chatchat.api.event.ChatChatEvent;
 import at.helpch.chatchat.api.event.MentionEvent;
+import at.helpch.chatchat.command.IgnoreCommand;
 import at.helpch.chatchat.user.ConsoleUser;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -36,6 +37,7 @@ public final class MessageProcessor {
     private static final String UTF_PERMISSION = "chatchat.utf";
     private static final String TAG_BASE_PERMISSION = "chatchat.tag.";
     private static final String ITEM_TAG_PERMISSION = TAG_BASE_PERMISSION + "item";
+    private static final String IGNORE_BYPASS_PERMISSION = IgnoreCommand.IGNORE_PERMISSION + ".bypass";
 
     private static final Map<String, TagResolver> PERMISSION_TAGS = Map.ofEntries(
         Map.entry("click", StandardTags.clickEvent()),
@@ -99,6 +101,9 @@ public final class MessageProcessor {
                 userIsTarget = true;
                 continue;
             }
+
+            if (target.ignoredUsers().contains(user.uuid()) &&
+                !user.player().hasPermission(IGNORE_BYPASS_PERMISSION)) continue;
 
             if (target instanceof ConsoleUser) continue;
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -6,10 +6,7 @@ import at.helpch.chatchat.api.ChatUser;
 import at.helpch.chatchat.api.MentionType;
 import at.helpch.chatchat.api.event.ChatChatEvent;
 import at.helpch.chatchat.api.event.MentionEvent;
-import at.helpch.chatchat.command.IgnoreCommand;
 import at.helpch.chatchat.user.ConsoleUser;
-import java.util.Map;
-import java.util.regex.Pattern;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -18,7 +15,11 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.minimessage.tag.standard.StandardTags;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+import java.util.regex.Pattern;
+
 public final class MessageProcessor {
+
     private static final Pattern DEFAULT_URL_PATTERN = Pattern.compile("(?:(https?)://)?([-\\w_.]+\\.\\w{2,})(/\\S*)?");
     private static final Pattern URL_SCHEME_PATTERN = Pattern.compile("^[a-z][a-z\\d+\\-.]*:");
 
@@ -37,7 +38,6 @@ public final class MessageProcessor {
     private static final String UTF_PERMISSION = "chatchat.utf";
     private static final String TAG_BASE_PERMISSION = "chatchat.tag.";
     private static final String ITEM_TAG_PERMISSION = TAG_BASE_PERMISSION + "item";
-    private static final String IGNORE_BYPASS_PERMISSION = IgnoreCommand.IGNORE_PERMISSION + ".bypass";
 
     private static final Map<String, TagResolver> PERMISSION_TAGS = Map.ofEntries(
         Map.entry("click", StandardTags.clickEvent()),
@@ -101,9 +101,6 @@ public final class MessageProcessor {
                 userIsTarget = true;
                 continue;
             }
-
-            if (target.ignoredUsers().contains(user.uuid()) &&
-                !user.player().hasPermission(IGNORE_BYPASS_PERMISSION)) continue;
 
             if (target instanceof ConsoleUser) continue;
 
@@ -348,4 +345,5 @@ public final class MessageProcessor {
             ? MessageUtils.parseToMiniMessage(message, resolver.build())
             : MessageUtils.parseToMiniMessage(message, resolver.build()).replaceText(URL_REPLACER_CONFIG);
     }
+
 }


### PR DESCRIPTION
Resolves #80

### Commands
Added `/ignore <player>`

### Permissions
Permission: `chatchat.ignore`
Bypass Permission: `chatchat.ignore.bypass`

#### Potential Changes: 
- [ ] Ignored players can't see your chat. Currently, it only blocks their chat from getting to you. This would block chat both ways
- [ ] Change the way `<player>` works in the command's success message. Currently just uses Player#getDisplayName(). Could instead allow PAPI Placeholders so they could use like %vault_displayname% for example.

#### Notes
This probably shouldn't be merged until the storage system is setup that way ignored players will be saved across restarts. Marked as draft for now.