### PR TITLE
Added getHandlerList for PMSendEvent

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -19,6 +19,10 @@ public class PMSendEvent extends Event implements Cancellable {
     private @NotNull Format recipientFormat;
     private @NotNull Component message;
     private final boolean reply;
+    
+    public static @NotNull HandlerList getHandlerList() {
+        return HANDLERS;
+    }
 
     public PMSendEvent(
         @NotNull final ChatUser sender,


### PR DESCRIPTION
It seems like this has been forgotten for the PMSendEvent, the ChatChatEvent and MentionEvent both have this, but this one doesn't.