### PR TITLE
Added a way to completely disable PMs on the server

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -195,12 +195,17 @@ public final class ChatChatPlugin extends JavaPlugin {
                 new IgnoreCommand(this),
                 new ReloadCommand(this),
                 new MentionToggleCommand(this),
+                new FormatTestCommand(this)
+        ).forEach(commandManager::registerCommand);
+
+        if (configManager.settings().privateMessagesSettings().enabled()) {
+            List.of(
                 new WhisperCommand(this, false),
                 new ReplyCommand(this, new WhisperCommand(this, true)),
                 new WhisperToggleCommand(this),
-                new SocialSpyCommand(this),
-                new FormatTestCommand(this)
-        ).forEach(commandManager::registerCommand);
+                new SocialSpyCommand(this)
+            ).forEach(commandManager::registerCommand);
+        }
 
         // register channel commands
         configManager.channels().channels().values().stream()

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReplyCommand.java
@@ -24,6 +24,11 @@ public final class ReplyCommand extends BaseCommand {
     @Default
     @Permission(MESSAGE_PERMISSION)
     public void reply(final ChatUser user, @Join final String message) {
+        if (!plugin.configManager().settings().privateMessagesSettings().enabled()) {
+            user.sendMessage(plugin.configManager().messages().unknownCommand());
+            return;
+        }
+
         final var lastMessaged = user.lastMessagedUser();
 
         if (lastMessaged.isEmpty()) {

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
-import java.util.Map;
 
 @Command(value = "whisper", alias = {"tell", "w", "msg", "message", "pm"})
 public final class WhisperCommand extends BaseCommand {
@@ -40,6 +39,10 @@ public final class WhisperCommand extends BaseCommand {
         @Suggestion(value = "recipients") final ChatUser recipient,
         @Join final String message
     ) {
+        if (!plugin.configManager().settings().privateMessagesSettings().enabled()) {
+            user.sendMessage(plugin.configManager().messages().unknownCommand());
+            return;
+        }
 
         if (!user.privateMessages()) {
             user.sendMessage(plugin.configManager().messages().repliesDisabled());
@@ -73,9 +76,9 @@ public final class WhisperCommand extends BaseCommand {
 
         final var settingsConfig = plugin.configManager().settings();
 
-        final var senderFormat = settingsConfig.senderFormat();
-        final var recipientFormat = settingsConfig.recipientFormat();
-        final var socialSpyFormat = settingsConfig.socialSpyFormat();
+        final var senderFormat = settingsConfig.privateMessagesSettings().formats().senderFormat();
+        final var recipientFormat = settingsConfig.privateMessagesSettings().formats().recipientFormat();
+        final var socialSpyFormat = settingsConfig.privateMessagesSettings().formats().socialSpyFormat();
 
         final var pmSendEvent = new PMSendEvent(
             user,

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
@@ -1,10 +1,10 @@
 package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.config.holders.ChannelsHolder;
-import at.helpch.chatchat.config.holders.FormatsHolder;
-import at.helpch.chatchat.config.holders.MessagesHolder;
-import at.helpch.chatchat.config.holders.SettingsHolder;
+import at.helpch.chatchat.config.holder.ChannelsHolder;
+import at.helpch.chatchat.config.holder.FormatsHolder;
+import at.helpch.chatchat.config.holder.MessagesHolder;
+import at.helpch.chatchat.config.holder.SettingsHolder;
 import at.helpch.chatchat.config.mapper.ChannelMapMapper;
 import at.helpch.chatchat.config.mapper.ChatFormatMapper;
 import at.helpch.chatchat.config.mapper.MiniMessageComponentMapper;

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -2,14 +2,12 @@ package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.channel.ChatChannel;
-import at.helpch.chatchat.config.holders.ChannelsHolder;
-import at.helpch.chatchat.config.holders.FormatsHolder;
-import at.helpch.chatchat.config.holders.MessagesHolder;
-import at.helpch.chatchat.config.holders.SettingsHolder;
+import at.helpch.chatchat.config.holder.ChannelsHolder;
+import at.helpch.chatchat.config.holder.FormatsHolder;
+import at.helpch.chatchat.config.holder.MessagesHolder;
+import at.helpch.chatchat.config.holder.SettingsHolder;
 import at.helpch.chatchat.format.ChatFormat;
 import at.helpch.chatchat.format.DefaultFormatFactory;
-import dev.triumphteam.cmd.bukkit.message.BukkitMessageKey;
-import dev.triumphteam.cmd.core.message.MessageKey;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/ChannelsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/ChannelsHolder.java
@@ -1,4 +1,4 @@
-package at.helpch.chatchat.config.holders;
+package at.helpch.chatchat.config.holder;
 
 import at.helpch.chatchat.api.Channel;
 import at.helpch.chatchat.config.DefaultConfigObjects;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolder.java
@@ -1,4 +1,4 @@
-package at.helpch.chatchat.config.holders;
+package at.helpch.chatchat.config.holder;
 
 import at.helpch.chatchat.config.DefaultConfigObjects;
 import at.helpch.chatchat.format.BasicFormat;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/MessagesHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/MessagesHolder.java
@@ -1,4 +1,4 @@
-package at.helpch.chatchat.config.holders;
+package at.helpch.chatchat.config.holder;
 
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/PMSettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/PMSettingsHolder.java
@@ -1,0 +1,45 @@
+package at.helpch.chatchat.config.holder;
+
+import at.helpch.chatchat.config.DefaultConfigObjects;
+import at.helpch.chatchat.format.BasicFormat;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+// configurate requires non-final fields
+@SuppressWarnings("FieldMayBeFinal")
+@ConfigSerializable
+public final class PMSettingsHolder {
+
+    private boolean enabled = true;
+
+    private PMFormats formats = new PMFormats();
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public PMFormats formats() {
+        return formats;
+    }
+
+    // configurate requires non-final fields
+    @SuppressWarnings("FieldMayBeFinal")
+    @ConfigSerializable
+    public static final class PMFormats {
+        private BasicFormat senderFormat = DefaultConfigObjects.createPrivateMessageSenderFormat();
+        private BasicFormat recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
+        private BasicFormat socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
+
+        public @NotNull BasicFormat senderFormat() {
+            return senderFormat;
+        }
+
+        public @NotNull BasicFormat recipientFormat() {
+            return recipientFormat;
+        }
+
+        public @NotNull BasicFormat socialSpyFormat() {
+            return socialSpyFormat;
+        }
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/SettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/SettingsHolder.java
@@ -1,4 +1,4 @@
-package at.helpch.chatchat.config.holders;
+package at.helpch.chatchat.config.holder;
 
 import at.helpch.chatchat.config.DefaultConfigObjects;
 import at.helpch.chatchat.format.BasicFormat;
@@ -11,10 +11,7 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 @ConfigSerializable
 public final class SettingsHolder {
 
-    private BasicFormat senderFormat = DefaultConfigObjects.createPrivateMessageSenderFormat();
-
-    private BasicFormat recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
-    private BasicFormat socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
+    private PMSettingsHolder privateMessages = new PMSettingsHolder();
 
     private String itemFormat = "<gray>[</gray><item><gray> x <amount>]";
     private String itemFormatInfo = "<dark_gray><item> x <amount>";
@@ -25,16 +22,8 @@ public final class SettingsHolder {
     private Sound mentionSound = DefaultConfigObjects.createMentionSound();
     private boolean mentionOnMessage = true;
 
-    public @NotNull BasicFormat senderFormat() {
-        return senderFormat;
-    }
-
-    public @NotNull BasicFormat recipientFormat() {
-        return recipientFormat;
-    }
-
-    public @NotNull BasicFormat socialSpyFormat() {
-        return socialSpyFormat;
+    public @NotNull PMSettingsHolder privateMessagesSettings() {
+        return privateMessages;
     }
 
     public @NotNull String itemFormat() {

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.util;
 
 import at.helpch.chatchat.api.Format;
-import at.helpch.chatchat.config.holders.FormatsHolder;
+import at.helpch.chatchat.config.holder.FormatsHolder;
 import at.helpch.chatchat.format.ChatFormat;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -1,40 +1,44 @@
 # The format to send to the sender of a private message
 # All formats can be formatted using MiniMessage: https://docs.adventure.kyori.net/minimessage/index.html
-sender-format:
-  parts:
-    sender:
-      - '<gray>you'
-    separator:
-      - ' <color:#40c9ff>-> '
-    recipient:
-      - '<gray><recipient:player_name>'
-    message:
-      - ' <#e81cff>» <white><message>'
-# The format to send to the recipient of a private message
-recipient-format:
-  parts:
-    sender:
-      - '<gray>%player_name%'
-    separator:
-      - ' <#40c9ff>-> '
-    recipient:
-      - '<gray>you'
-    message:
-      - ' <#e81cff>» <white><message>'
 
-# The format to send to any players with socialspy enabled
-social-spy-format:
-  parts:
-    prefix:
-      - '<gray>(spy) '
-    sender:
-      - '%player_name%'
-    separator:
-      - ' <#40c9ff>-> '
-    recipient:
-      - '<gray><recipient:player_name>'
-    message:
-      - ' <#e81cff>» <white><message>'
+private-messages:
+  enabled: true
+  formats:
+    sender-format:
+      parts:
+        sender:
+          - '<gray>you'
+        separator:
+          - ' <color:#40c9ff>-> '
+        recipient:
+          - '<gray><recipient:player_name>'
+        message:
+          - ' <#e81cff>» <white><message>'
+    # The format to send to the recipient of a private message
+    recipient-format:
+      parts:
+        sender:
+          - '<gray>%player_name%'
+        separator:
+          - ' <#40c9ff>-> '
+        recipient:
+          - '<gray>you'
+        message:
+          - ' <#e81cff>» <white><message>'
+
+    # The format to send to any players with socialspy enabled
+    social-spy-format:
+      parts:
+        prefix:
+          - '<gray>(spy) '
+        sender:
+          - '%player_name%'
+        separator:
+          - ' <#40c9ff>-> '
+        recipient:
+          - '<gray><recipient:player_name>'
+        message:
+          - ' <#e81cff>» <white><message>'
 
 # The format that the <item> placeholder will use in chat. Needs to contain <item>.
 # Another available internal placeholder is <amount>.


### PR DESCRIPTION
DeluxeChat had this option so its basically a parity feature that was missing. This does change the config.yml options a bit tho.

The way it works:
- If its enabled, you disable it and do /chatchat reload, you will get the "invalid command" message.
- if its enabled, you disable it and you restart the server, the PM related commands will not be registered at all.
- If its disabled and you enable it, it will require a restart for the commands to be registered.

Closes #135 