### PR TITLE
Fixed papi tag sometimes not parsing, and updated the papi-rel tag to work like the papi tag.

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
@@ -20,14 +20,11 @@ public final class PapiTagUtils {
                 return null;
             }
 
-            final String next = argumentQueue.pop().value().toLowerCase(Locale.ROOT);
-            if (!argumentQueue.hasNext()) {
-                return null;
-            }
+            final String next = argumentQueue.pop().value();
 
             final boolean inserting;
             final boolean append;
-            switch (next) {
+            switch (next.toLowerCase(Locale.ROOT)) {
                 case "closing":
                     inserting = false;
                     append = false;
@@ -57,6 +54,10 @@ public final class PapiTagUtils {
             }
 
             final var parsedPlaceholder = PlaceholderAPI.setPlaceholders(player, '%' + placeholder + '%');
+            if (parsedPlaceholder.equals("%" + placeholder + '%')) {
+                return null;
+            }
+
             final var kyorifiedPlaceholder = Kyorifier.kyorify(parsedPlaceholder);
             final var componentPlaceholder = MessageUtils.parseToMiniMessage(kyorifiedPlaceholder);
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/PapiTagUtils.java
@@ -74,24 +74,30 @@ public final class PapiTagUtils {
                 return null;
             }
 
-            final String next = argumentQueue.pop().value().toLowerCase(Locale.ROOT);
-            if (!argumentQueue.hasNext()) {
-                return null;
-            }
+            final String next = argumentQueue.pop().value();
 
             final boolean inserting;
-            switch (next) {
+            final boolean append;
+            switch (next.toLowerCase(Locale.ROOT)) {
                 case "closing":
                     inserting = false;
+                    append = false;
                     break;
                 case "inserting":
                     inserting = true;
+                    append = false;
                     break;
                 default:
-                    return null;
+                    inserting = false;
+                    append = true;
+                    break;
             }
 
             final var arguments = new ArrayList<String>();
+            if (append) {
+                arguments.add(next);
+            }
+
             while (argumentQueue.hasNext()) {
                 arguments.add(argumentQueue.pop().value());
             }
@@ -107,6 +113,10 @@ public final class PapiTagUtils {
                 target,
                 '%' + placeholder + '%'
             );
+            if (parsedPlaceholder.equals("%" + placeholder + '%')) {
+                return null;
+            }
+
             final var kyorifiedPlaceholder = Kyorifier.kyorify(parsedPlaceholder);
             final var componentPlaceholder = MessageUtils.parseToMiniMessage(kyorifiedPlaceholder);
 


### PR DESCRIPTION
What the title says. The `<papi:PLACEHOLDER>` tag wasn't working unless the `inserting` or `closing` arguments were present. It should've instead defaulted to closing. Also the papi-rel tag was working a bit differently than the papi tag which was a bug.

Closes #162 