### PR TITLE
Fixed priority format serialization

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/ChatChatEvent.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.api.event;
 
 import at.helpch.chatchat.api.channel.Channel;
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.api.user.ChatUser;
 import at.helpch.chatchat.api.user.User;
 import net.kyori.adventure.text.Component;
@@ -23,7 +23,7 @@ public class ChatChatEvent extends Event implements Cancellable {
     private boolean cancelled = false;
 
     private @NotNull final ChatUser user;
-    private @NotNull Format format;
+    private @NotNull PriorityFormat format;
     private @NotNull Component message;
     private @NotNull final Channel channel;
     private @NotNull final Set<User> recipients;
@@ -35,7 +35,7 @@ public class ChatChatEvent extends Event implements Cancellable {
     public ChatChatEvent(
         final boolean async,
         @NotNull final ChatUser user,
-        @NotNull final Format format,
+        @NotNull final PriorityFormat format,
         @NotNull final Component message,
         @NotNull final Channel channel,
         @NotNull Set<User> recipients) {
@@ -76,7 +76,7 @@ public class ChatChatEvent extends Event implements Cancellable {
      *
      * @return The format that will be used.
      */
-    public @NotNull Format format() {
+    public @NotNull PriorityFormat format() {
         return format;
     }
 
@@ -85,7 +85,7 @@ public class ChatChatEvent extends Event implements Cancellable {
      *
      * @param format The format that will be used.
      */
-    public void format(@NotNull final Format format) {
+    public void format(@NotNull final PriorityFormat format) {
         this.format = format;
     }
 

--- a/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
+++ b/api/src/main/java/at/helpch/chatchat/api/event/PMSendEvent.java
@@ -1,6 +1,6 @@
 package at.helpch.chatchat.api.event;
 
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.user.ChatUser;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.Cancellable;
@@ -18,8 +18,8 @@ public class PMSendEvent extends Event implements Cancellable {
 
     private @NotNull final ChatUser sender;
     private @NotNull final ChatUser recipient;
-    private @NotNull Format senderFormat;
-    private @NotNull Format recipientFormat;
+    private @NotNull SimpleFormat senderFormat;
+    private @NotNull SimpleFormat recipientFormat;
     private @NotNull Component message;
     private final boolean reply;
     
@@ -30,8 +30,8 @@ public class PMSendEvent extends Event implements Cancellable {
     public PMSendEvent(
         @NotNull final ChatUser sender,
         @NotNull final ChatUser recipient,
-        @NotNull final Format senderFormat,
-        @NotNull final Format recipientFormat,
+        @NotNull final SimpleFormat senderFormat,
+        @NotNull final SimpleFormat recipientFormat,
         @NotNull final Component message,
         final boolean reply
     ) {
@@ -77,38 +77,38 @@ public class PMSendEvent extends Event implements Cancellable {
     }
 
     /**
-     * Get the {@link Format} that will be used to format the message that the sender sees.
+     * Get the {@link SimpleFormat} that will be used to format the message that the sender sees.
      *
-     * @return the {@link Format} that will be used to format the message that the sender sees.
+     * @return the {@link SimpleFormat} that will be used to format the message that the sender sees.
      */
-    public @NotNull Format senderFormat() {
+    public @NotNull SimpleFormat senderFormat() {
         return senderFormat;
     }
 
     /**
-     * Change the {@link Format} that will be used to format the message that the sender sees.
+     * Change the {@link SimpleFormat} that will be used to format the message that the sender sees.
      *
-     * @param format the new {@link Format} that will be used to format the message that the sender sees.
+     * @param format the new {@link SimpleFormat} that will be used to format the message that the sender sees.
      */
-    public void senderFormat(@NotNull final Format format) {
+    public void senderFormat(@NotNull final SimpleFormat format) {
         this.senderFormat = format;
     }
 
     /**
-     * Get the {@link Format} that will be used to format the message that the recipient sees.
+     * Get the {@link SimpleFormat} that will be used to format the message that the recipient sees.
      *
-     * @return the {@link Format} that will be used to format the message that the recipient sees.
+     * @return the {@link SimpleFormat} that will be used to format the message that the recipient sees.
      */
-    public @NotNull Format recipientFormat() {
+    public @NotNull SimpleFormat recipientFormat() {
         return recipientFormat;
     }
 
     /**
-     * Change the {@link Format} that will be used to format the message that the recipient sees.
+     * Change the {@link SimpleFormat} that will be used to format the message that the recipient sees.
      *
-     * @param format the new {@link Format} that will be used to format the message that the recipient sees.
+     * @param format the new {@link SimpleFormat} that will be used to format the message that the recipient sees.
      */
-    public void recipientFormat(@NotNull final Format format) {
+    public void recipientFormat(@NotNull final SimpleFormat format) {
         this.recipientFormat = format;
     }
 

--- a/api/src/main/java/at/helpch/chatchat/api/format/Format.java
+++ b/api/src/main/java/at/helpch/chatchat/api/format/Format.java
@@ -5,9 +5,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Map;
 
-/**
- * This is a simple format.
- */
 public interface Format {
 
     /**

--- a/api/src/main/java/at/helpch/chatchat/api/format/PriorityFormat.java
+++ b/api/src/main/java/at/helpch/chatchat/api/format/PriorityFormat.java
@@ -3,7 +3,7 @@ package at.helpch.chatchat.api.format;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a basic {@link Format} that has a priority. These are usually used for player formats.
+ * Represents a simple {@link Format} that has a priority. These are usually used for player formats.
  */
 public interface PriorityFormat extends Format {
 

--- a/api/src/main/java/at/helpch/chatchat/api/format/SimpleFormat.java
+++ b/api/src/main/java/at/helpch/chatchat/api/format/SimpleFormat.java
@@ -1,0 +1,6 @@
+package at.helpch.chatchat.api.format;
+
+/**
+ * Represents a simple {@link Format}. These are usually used for private messages, mentions, console, etc.
+ */
+public interface SimpleFormat extends Format {}

--- a/api/src/main/java/at/helpch/chatchat/api/holder/GlobalFormatsHolder.java
+++ b/api/src/main/java/at/helpch/chatchat/api/holder/GlobalFormatsHolder.java
@@ -1,11 +1,11 @@
 package at.helpch.chatchat.api.holder;
 
-import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This is used to store the name of the default format, a {@link Format} that is used
+ * This is used to store the name of the default format, a {@link SimpleFormat} that is used
  * for console, and a list of {@link PriorityFormat}s.
  */
 public interface GlobalFormatsHolder extends FormatsHolder {
@@ -24,5 +24,5 @@ public interface GlobalFormatsHolder extends FormatsHolder {
      *
      * @return The console format.
      */
-    @NotNull Format consoleFormat();
+    @NotNull SimpleFormat consoleFormat();
 }

--- a/api/src/main/java/at/helpch/chatchat/api/user/User.java
+++ b/api/src/main/java/at/helpch/chatchat/api/user/User.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.api.user;
 
 import at.helpch.chatchat.api.channel.Channel;
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.PriorityFormat;
 import net.kyori.adventure.audience.ForwardingAudience;
 import net.kyori.adventure.identity.Identified;
 import org.jetbrains.annotations.NotNull;
@@ -34,14 +34,14 @@ public interface User extends ForwardingAudience.Single, Identified {
      * @return The user's chat format.
      * @WARNING This is currently not used by ChatChat at all!
      */
-    @NotNull Format format();
+    @NotNull PriorityFormat format();
 
     /**
      * Change the user's chat format.
      *
      * @param format The new chat format.
      */
-    void format(@NotNull final Format format);
+    void format(@NotNull final PriorityFormat format);
 
     /**
      * Get the user's unique identifier.

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -2,7 +2,7 @@ package at.helpch.chatchat.command;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.event.PMSendEvent;
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.user.ChatUser;
 import at.helpch.chatchat.util.FormatUtils;
 import dev.triumphteam.cmd.bukkit.annotation.Permission;
@@ -106,7 +106,7 @@ public final class WhisperCommand extends BaseCommand {
             return;
         }
 
-        final var formats = new LinkedHashMap<Audience, Format>();
+        final var formats = new LinkedHashMap<Audience, SimpleFormat>();
         formats.put(user, pmSendEvent.senderFormat());
         formats.put(recipient, pmSendEvent.recipientFormat());
         formats.put(
@@ -119,7 +119,7 @@ public final class WhisperCommand extends BaseCommand {
             socialSpyFormat
         );
 
-        formats.forEach((Audience audience, Format format) ->
+        formats.forEach((Audience audience, SimpleFormat format) ->
             audience.sendMessage(FormatUtils.parseFormat(
                 format,
                 user.player(),

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
@@ -1,8 +1,8 @@
 package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.holder.GlobalFormatsHolder;
 import at.helpch.chatchat.config.holder.ChannelsHolder;
 import at.helpch.chatchat.config.holder.GlobalFormatsHolderImpl;
@@ -14,7 +14,7 @@ import at.helpch.chatchat.config.mapper.ChannelMapMapper;
 import at.helpch.chatchat.config.mapper.MiniMessageComponentMapper;
 import at.helpch.chatchat.config.mapper.MiniPlaceholderMapper;
 import at.helpch.chatchat.config.mapper.PriorityFormatMapper;
-import at.helpch.chatchat.format.SimpleFormat;
+import at.helpch.chatchat.format.SimpleFormatImpl;
 import at.helpch.chatchat.format.ChatFormat;
 import at.helpch.chatchat.placeholder.MiniPlaceholderImpl;
 import io.leangen.geantyref.TypeToken;
@@ -98,8 +98,8 @@ public final class ConfigFactory {
                 .serializers(build -> build
                     .register(Component.class, new MiniMessageComponentMapper())
 
+                    .register(SimpleFormatImpl.class, new SimpleFormatMapper())
                     .register(SimpleFormat.class, new SimpleFormatMapper())
-                    .register(Format.class, new SimpleFormatMapper())
 
                     .register(PriorityFormat.class, new PriorityFormatMapper())
                     .register(ChatFormat.class, new PriorityFormatMapper())

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -1,11 +1,11 @@
 package at.helpch.chatchat.config;
 
 import at.helpch.chatchat.api.channel.Channel;
-import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.config.holder.FormatsHolderImpl;
-import at.helpch.chatchat.format.SimpleFormat;
+import at.helpch.chatchat.format.SimpleFormatImpl;
 import at.helpch.chatchat.format.ChatFormat;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
@@ -29,14 +29,14 @@ public final class DefaultConfigObjects {
             List.of("staffchat"), "<gray>[<green>Staff<gray>]", new FormatsHolderImpl(), -1);
     }
 
-    public static @NotNull Format createDefaultConsoleFormat() {
+    public static @NotNull SimpleFormat createDefaultConsoleFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put("channel", List.of("%chatchat_channel_prefix% "));
         map.put("prefix", List.of("<gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] "));
         map.put("name", List.of("<white>%player_name%"));
         map.put("message", List.of(" <gray>» <white><message>"));
-        return new SimpleFormat("console-format", map);
+        return new SimpleFormatImpl("console-format", map);
     }
 
     public static @NotNull PriorityFormat createDefaultChannelFormat() {
@@ -84,7 +84,7 @@ public final class DefaultConfigObjects {
         return new ChatFormat("other", 1, map);
     }
 
-    public static @NotNull Format createPrivateMessageSenderFormat() {
+    public static @NotNull SimpleFormat createPrivateMessageSenderFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put("sender", List.of("<gray>you"));
@@ -92,10 +92,10 @@ public final class DefaultConfigObjects {
         map.put("recipient", List.of("<gray><recipient:player_name>"));
         map.put("message", List.of(" <#e81cff>» <white><message>"));
 
-        return new SimpleFormat("sender", map);
+        return new SimpleFormatImpl("sender", map);
     }
 
-    public static @NotNull Format createPrivateMessageRecipientFormat() {
+    public static @NotNull SimpleFormat createPrivateMessageRecipientFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put("sender", List.of("<gray>%player_name%"));
@@ -103,10 +103,10 @@ public final class DefaultConfigObjects {
         map.put("recipient", List.of("<gray>you"));
         map.put("message", List.of(" <#e81cff>» <white><message>"));
 
-        return new SimpleFormat("recipient", map);
+        return new SimpleFormatImpl("recipient", map);
     }
 
-    public static @NotNull Format createPrivateMessageSocialSpyFormat() {
+    public static @NotNull SimpleFormat createPrivateMessageSocialSpyFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put("prefix", List.of("<gray>(spy) "));
@@ -115,10 +115,10 @@ public final class DefaultConfigObjects {
         map.put("recipient", List.of("<gray><recipient:player_name>"));
         map.put("message", List.of(" <#e81cff>» <white><message>"));
 
-        return new SimpleFormat("socialspy", map);
+        return new SimpleFormatImpl("socialspy", map);
     }
 
-    public static @NotNull Format createPersonalMentionFormat() {
+    public static @NotNull SimpleFormat createPersonalMentionFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put(
@@ -130,10 +130,10 @@ public final class DefaultConfigObjects {
             )
         );
 
-        return new SimpleFormat("personal-mention", map);
+        return new SimpleFormatImpl("personal-mention", map);
     }
 
-    public static @NotNull Format createChannelMentionFormat() {
+    public static @NotNull SimpleFormat createChannelMentionFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
 
         map.put(
@@ -145,7 +145,7 @@ public final class DefaultConfigObjects {
             )
         );
 
-        return new SimpleFormat("channel-mention", map);
+        return new SimpleFormatImpl("channel-mention", map);
     }
 
     public static @NotNull Sound createMentionSound() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/GlobalFormatsHolderImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/GlobalFormatsHolderImpl.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.config.holder;
 
-import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.holder.GlobalFormatsHolder;
 import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +16,7 @@ public final class GlobalFormatsHolderImpl implements GlobalFormatsHolder {
 
     private String defaultFormat = "default";
 
-    private Format consoleFormat = DefaultConfigObjects.createDefaultConsoleFormat();
+    private SimpleFormat consoleFormat = DefaultConfigObjects.createDefaultConsoleFormat();
 
     private Map<String, PriorityFormat> formats = Map.of(
         "other", DefaultConfigObjects.createOtherFormat(),
@@ -26,7 +26,7 @@ public final class GlobalFormatsHolderImpl implements GlobalFormatsHolder {
         return defaultFormat;
     }
 
-    public @NotNull Format consoleFormat() {
+    public @NotNull SimpleFormat consoleFormat() {
         return consoleFormat;
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/MentionSettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/MentionSettingsHolder.java
@@ -1,6 +1,6 @@
 package at.helpch.chatchat.config.holder;
 
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.config.DefaultConfigObjects;
 import net.kyori.adventure.sound.Sound;
 import org.jetbrains.annotations.NotNull;
@@ -14,8 +14,8 @@ public final class MentionSettingsHolder {
     private String prefix = "@";
     private Sound sound = DefaultConfigObjects.createMentionSound();
     private boolean privateMessage = true;
-    private Format personalFormat = DefaultConfigObjects.createPersonalMentionFormat();
-    private Format channelFormat = DefaultConfigObjects.createChannelMentionFormat();
+    private SimpleFormat personalFormat = DefaultConfigObjects.createPersonalMentionFormat();
+    private SimpleFormat channelFormat = DefaultConfigObjects.createChannelMentionFormat();
 
     public @NotNull String prefix() {
         return prefix;
@@ -29,11 +29,11 @@ public final class MentionSettingsHolder {
         return privateMessage;
     }
 
-    public @NotNull Format personalFormat() {
+    public @NotNull SimpleFormat personalFormat() {
         return personalFormat;
     }
 
-    public @NotNull Format channelFormat() {
+    public @NotNull SimpleFormat channelFormat() {
         return channelFormat;
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/PMSettingsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/PMSettingsHolder.java
@@ -1,6 +1,6 @@
 package at.helpch.chatchat.config.holder;
 
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -26,19 +26,19 @@ public final class PMSettingsHolder {
     @SuppressWarnings("FieldMayBeFinal")
     @ConfigSerializable
     public static final class PMFormats {
-        private Format senderFormat = DefaultConfigObjects.createPrivateMessageSenderFormat();
-        private Format recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
-        private Format socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
+        private SimpleFormat senderFormat = DefaultConfigObjects.createPrivateMessageSenderFormat();
+        private SimpleFormat recipientFormat = DefaultConfigObjects.createPrivateMessageRecipientFormat();
+        private SimpleFormat socialSpyFormat = DefaultConfigObjects.createPrivateMessageSocialSpyFormat();
 
-        public @NotNull Format senderFormat() {
+        public @NotNull SimpleFormat senderFormat() {
             return senderFormat;
         }
 
-        public @NotNull Format recipientFormat() {
+        public @NotNull SimpleFormat recipientFormat() {
             return recipientFormat;
         }
 
-        public @NotNull Format socialSpyFormat() {
+        public @NotNull SimpleFormat socialSpyFormat() {
             return socialSpyFormat;
         }
     }

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/SimpleFormatMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/SimpleFormatMapper.java
@@ -1,7 +1,7 @@
 package at.helpch.chatchat.config.mapper;
 
-import at.helpch.chatchat.api.format.Format;
-import at.helpch.chatchat.format.SimpleFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
+import at.helpch.chatchat.format.SimpleFormatImpl;
 import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public final class SimpleFormatMapper implements TypeSerializer<Format> {
+public final class SimpleFormatMapper implements TypeSerializer<SimpleFormat> {
 
     private static final TypeToken<Map<String, List<String>>> mapTypeToken = new TypeToken<>() {};
     private static final String PARTS = "parts";
@@ -26,7 +26,7 @@ public final class SimpleFormatMapper implements TypeSerializer<Format> {
     }
 
     @Override
-    public Format deserialize(Type type, ConfigurationNode node) throws SerializationException {
+    public SimpleFormat deserialize(Type type, ConfigurationNode node) throws SerializationException {
         final var keyNode = node.key();
         if (keyNode == null) {
             throw new SerializationException("A config key cannot be null!");
@@ -38,11 +38,11 @@ public final class SimpleFormatMapper implements TypeSerializer<Format> {
             throw new SerializationException("Parts list of node: " + key + " cannot be null!");
         }
 
-        return new SimpleFormat(key, parts);
+        return new SimpleFormatImpl(key, parts);
     }
 
     @Override
-    public void serialize(Type type, @Nullable Format format, ConfigurationNode target) throws SerializationException {
+    public void serialize(Type type, @Nullable SimpleFormat format, ConfigurationNode target) throws SerializationException {
         if (format == null) {
             target.raw(null);
             return;

--- a/plugin/src/main/java/at/helpch/chatchat/format/SimpleFormatImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/format/SimpleFormatImpl.java
@@ -1,6 +1,6 @@
 package at.helpch.chatchat.format;
 
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -9,12 +9,12 @@ import java.util.List;
 import java.util.Map;
 
 @ConfigSerializable
-public final class SimpleFormat implements Format {
+public final class SimpleFormatImpl implements SimpleFormat {
 
     private final String name;
     private final Map<String, List<String>> parts;
 
-    public SimpleFormat(@NotNull final String name, @NotNull final Map<String, List<String>> parts) {
+    public SimpleFormatImpl(@NotNull final String name, @NotNull final Map<String, List<String>> parts) {
         this.name = name;
         this.parts = Collections.unmodifiableMap(parts);
     }
@@ -25,8 +25,8 @@ public final class SimpleFormat implements Format {
     }
 
     @Override
-    public @NotNull SimpleFormat name(@NotNull String name) {
-        return new SimpleFormat(name, parts);
+    public @NotNull SimpleFormatImpl name(@NotNull String name) {
+        return new SimpleFormatImpl(name, parts);
     }
 
     @Override
@@ -35,8 +35,8 @@ public final class SimpleFormat implements Format {
     }
 
     @Override
-    public @NotNull SimpleFormat parts(@NotNull final Map<String, List<String>> parts) {
-        return new SimpleFormat(name, parts);
+    public @NotNull SimpleFormatImpl parts(@NotNull final Map<String, List<String>> parts) {
+        return new SimpleFormatImpl(name, parts);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -2,7 +2,7 @@ package at.helpch.chatchat.user;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.channel.Channel;
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.api.user.ChatUser;
 import at.helpch.chatchat.api.user.User;
 import at.helpch.chatchat.cache.ExpiringCache;
@@ -33,7 +33,7 @@ public final class ChatUserImpl implements ChatUser {
     private final UUID uuid;
     private Channel channel;
     // TODO: 8/9/22 Remove unused field!
-    private Format format;
+    private PriorityFormat format;
     private boolean privateMessages = true;
     private boolean personalMentions = true;
     private boolean channelMentions = true;
@@ -51,12 +51,12 @@ public final class ChatUserImpl implements ChatUser {
     }
 
     @Override
-    public @NotNull Format format() {
+    public @NotNull PriorityFormat format() {
         return format;
     }
 
     @Override
-    public void format(@NotNull final Format format) {
+    public void format(@NotNull final PriorityFormat format) {
         this.format = format;
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ConsoleUser.java
@@ -2,7 +2,7 @@ package at.helpch.chatchat.user;
 
 import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.channel.Channel;
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.api.user.User;
 import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.format.ChatFormat;
@@ -30,12 +30,12 @@ public final class ConsoleUser implements User {
     }
 
     @Override
-    public @NotNull Format format() {
+    public @NotNull PriorityFormat format() {
         return ChatFormat.defaultFormat();
     }
 
     @Override
-    public void format(@NotNull final Format format) {
+    public void format(@NotNull final PriorityFormat format) {
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java
@@ -3,6 +3,7 @@ package at.helpch.chatchat.util;
 import at.helpch.chatchat.api.channel.Channel;
 import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.holder.GlobalFormatsHolder;
 import at.helpch.chatchat.format.ChatFormat;
 import me.clip.placeholderapi.PlaceholderAPI;
@@ -54,7 +55,7 @@ public final class FormatUtils {
     }
 
     public static @NotNull Component parseConsoleFormat(
-        @NotNull final Format format,
+        @NotNull final SimpleFormat format,
         @NotNull final Player player) {
         return MessageUtils.parseToMiniMessage(
             PlaceholderAPI.setPlaceholders(

--- a/plugin/src/main/java/at/helpch/chatchat/util/MentionUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MentionUtils.java
@@ -1,6 +1,6 @@
 package at.helpch.chatchat.util;
 
-import at.helpch.chatchat.api.format.Format;
+import at.helpch.chatchat.api.format.SimpleFormat;
 import at.helpch.chatchat.api.user.ChatUser;
 import at.helpch.chatchat.api.user.User;
 import net.kyori.adventure.text.Component;
@@ -71,7 +71,7 @@ public final class MentionUtils {
         @RegExp @NotNull final String username,
         @NotNull final User user,
         @NotNull final Component component,
-        @NotNull final Format format) {
+        @NotNull final SimpleFormat format) {
         return replaceMention(username, component, (r) -> user instanceof ChatUser
             ? FormatUtils.parseFormat(format, ((ChatUser) user).player(), component)
             : FormatUtils.parseFormat(format, component));
@@ -82,7 +82,7 @@ public final class MentionUtils {
         @NotNull final ChatUser user,
         @NotNull final String prefix,
         @NotNull final Component component,
-        @NotNull final Format format
+        @NotNull final SimpleFormat format
     ) {
         return replaceMention(prefix + user.player().getName(), component,
             r -> FormatUtils.parseFormat(format, user.player(), component));
@@ -90,7 +90,7 @@ public final class MentionUtils {
 
     public static @NotNull Map.Entry<@NotNull Boolean, @NotNull Component> processChannelMentions(
         @NotNull final String mentionPrefix,
-        @NotNull final Format channelMentionFormat,
+        @NotNull final SimpleFormat channelMentionFormat,
         @NotNull final ChatUser user,
         @NotNull final User target,
         @NotNull final Component message
@@ -118,7 +118,7 @@ public final class MentionUtils {
 
     public static @NotNull Map.Entry<@NotNull Boolean, @NotNull Component> processPersonalMentions(
         @NotNull final String mentionPrefix,
-        @NotNull final Format mentionFormat,
+        @NotNull final SimpleFormat mentionFormat,
         @NotNull final ChatUser user,
         @NotNull final ChatUser target,
         @NotNull final Component message


### PR DESCRIPTION
In #143 I had an interface called BasicFormat but I forgot why and I only remembered after that was merged :). It existed because otherwise there were problems with the serialization. Basically, priority formats were serialized as if they were basic formats. I re-added basic formats but with a different name in this PR.