### PR TITLE
Some small fixes and quality of life improvements.

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
+++ b/plugin/src/main/java/at/helpch/chatchat/ChatChatPlugin.java
@@ -126,7 +126,16 @@ public final class ChatChatPlugin extends JavaPlugin {
             20 * 60 * 5L // Run the user save task every 5 minutes.
         );
 
+        final int formats = configManager.formats().formats().size();
+        final int channels = configManager.channels().channels().size();
+        final int channelFormats = configManager.channels().channels().values().stream()
+            .mapToInt(channel -> channel.formats().formats().size())
+            .sum();
+
         getLogger().info("Plugin enabled successfully!");
+        getLogger().info(formats + (formats == 1 ? " format" : " formats") + " loaded!");
+        getLogger().info(channels + (channels == 1 ? " channel" : " channels") + " loaded!");
+        getLogger().info(channelFormats + (channelFormats == 1 ? " channel format" : " channel formats") + " loaded!");
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -27,6 +27,9 @@ public final class ReloadCommand extends ChatChatCommand {
 
         final int formats = plugin.configManager().formats().formats().size();
         final int channels = plugin.configManager().channels().channels().size();
+        final int channelFormats = plugin.configManager().channels().channels().values().stream()
+            .mapToInt(channel -> channel.formats().formats().size())
+            .sum();
 
         sender.sendMessage(text("Chat", TextColor.fromCSSHexString("#40c9ff"))
                 .append(text("Chat", TextColor.fromCSSHexString("#e81cff")))
@@ -36,6 +39,10 @@ public final class ReloadCommand extends ChatChatCommand {
                 .append(text((formats == 1 ? " format" : " formats") + " loaded!", NamedTextColor.GREEN))
                 .append(Component.newline())
                 .append(text(channels, NamedTextColor.WHITE))
-                .append(text((channels == 1 ? " channel" : " channels") + " loaded!", NamedTextColor.GREEN)));
+                .append(text((channels == 1 ? " channel" : " channels") + " loaded!", NamedTextColor.GREEN))
+                .append(Component.newline())
+                .append(text(channelFormats, NamedTextColor.WHITE))
+                .append(text(" channel " + (channelFormats == 1 ? "format" : "formats") + " loaded!", NamedTextColor.GREEN))
+        );
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -33,9 +33,9 @@ public final class ReloadCommand extends ChatChatCommand {
                 .append(text(" Reloaded Successfully!", NamedTextColor.GREEN))
                 .append(Component.newline())
                 .append(text(formats, NamedTextColor.WHITE))
-                .append(text(formats == 1 ? " format" : " formats" + " loaded!", NamedTextColor.GREEN))
+                .append(text((formats == 1 ? " format" : " formats") + " loaded!", NamedTextColor.GREEN))
                 .append(Component.newline())
                 .append(text(channels, NamedTextColor.WHITE))
-                .append(text(channels == 1 ? " channel" : " channels" + " loaded!", NamedTextColor.GREEN)));
+                .append(text((channels == 1 ? " channel" : " channels") + " loaded!", NamedTextColor.GREEN)));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/ReloadCommand.java
@@ -42,7 +42,7 @@ public final class ReloadCommand extends ChatChatCommand {
                 .append(text((channels == 1 ? " channel" : " channels") + " loaded!", NamedTextColor.GREEN))
                 .append(Component.newline())
                 .append(text(channelFormats, NamedTextColor.WHITE))
-                .append(text(" channel " + (channelFormats == 1 ? "format" : "formats") + " loaded!", NamedTextColor.GREEN))
+                .append(text((channelFormats == 1 ? " channel format" : " channel formats") + " loaded!", NamedTextColor.GREEN))
         );
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -39,11 +39,15 @@ public final class ConfigManager {
 
         channels();
         final var defaultChannel = channels.channels().get(channels.defaultChannel());
-        ChatChannel.defaultChannel(
-            defaultChannel instanceof ChatChannel
-                ? defaultChannel
-                : DefaultConfigObjects.createDefaultChannel()
-        );
+        if (defaultChannel instanceof ChatChannel) {
+            ChatChannel.defaultChannel(defaultChannel);
+        } else {
+            plugin.getLogger().warning(
+                "Could not find a channel named " + channels.defaultChannel() + "." + System.lineSeparator() +
+                    "Using an internal channel as the default channel."
+            );
+            ChatChannel.defaultChannel(DefaultConfigObjects.createDefaultChannel());
+        }
 
         settings();
 

--- a/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/DefaultConfigObjects.java
@@ -39,21 +39,6 @@ public final class DefaultConfigObjects {
         return new SimpleFormat("console-format", map);
     }
 
-    public static @NotNull PriorityFormat createDefaultChannelFormat() {
-        final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();
-
-        map.put("channel", List.of(
-            "<hover:show_text:'<aqua>This is a default channel format!'>",
-            "%chatchat_channel_prefix%",
-            "</hover>"
-        ));
-        map.put("prefix", List.of(" <gray>[<color:#40c9ff>Chat<color:#e81cff>Chat<gray>] "));
-        map.put("name", List.of("<white>%player_name%"));
-        map.put("message", List.of(" <gray>» <white><message>"));
-
-        return new ChatFormat("default-channel", 1, map);
-    }
-
 
     public static @NotNull PriorityFormat createDefaultFormat() {
         final LinkedHashMap<String, List<String>> map = new LinkedHashMap<>();

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolderImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolderImpl.java
@@ -2,7 +2,6 @@ package at.helpch.chatchat.config.holder;
 
 import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.api.holder.FormatsHolder;
-import at.helpch.chatchat.config.DefaultConfigObjects;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
@@ -13,8 +12,7 @@ import java.util.Map;
 @ConfigSerializable
 public class FormatsHolderImpl implements FormatsHolder {
 
-    private Map<String, PriorityFormat> formats = Map.of(
-        "default-channel", DefaultConfigObjects.createDefaultChannelFormat());
+    private Map<String, PriorityFormat> formats = Map.of();
 
     public @NotNull Map<String, PriorityFormat> formats() {
         return Map.copyOf(formats);

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolderImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/FormatsHolderImpl.java
@@ -12,6 +12,13 @@ import java.util.Map;
 @ConfigSerializable
 public class FormatsHolderImpl implements FormatsHolder {
 
+    public FormatsHolderImpl() {
+    }
+
+    public FormatsHolderImpl(Map<String, PriorityFormat> formats) {
+        this.formats = formats;
+    }
+
     private Map<String, PriorityFormat> formats = Map.of();
 
     public @NotNull Map<String, PriorityFormat> formats() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/ChannelMapper.java
@@ -1,8 +1,10 @@
 package at.helpch.chatchat.config.mapper;
 
 import at.helpch.chatchat.api.channel.Channel;
+import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.channel.ChannelTypeRegistryImpl;
 import at.helpch.chatchat.config.holder.FormatsHolderImpl;
+import io.leangen.geantyref.TypeToken;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -10,6 +12,7 @@ import org.spongepowered.configurate.serialize.TypeSerializer;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Map;
 
 public final class ChannelMapper implements TypeSerializer<Channel> {
 
@@ -19,6 +22,7 @@ public final class ChannelMapper implements TypeSerializer<Channel> {
     private static final String FORMATS = "formats";
     private static final String RADIUS = "radius";
     private static final String TYPE = "type";
+    private static final TypeToken<Map<String, PriorityFormat>> FORMATS_MAP_TYPE = new TypeToken<>() {};
 
     private final ChannelTypeRegistryImpl registry;
 
@@ -48,7 +52,8 @@ public final class ChannelMapper implements TypeSerializer<Channel> {
 
         final var messagePrefix = node.node(MESSAGE_PREFIX).getString("");
         final var channelPrefix = node.node(CHANNEL_PREFIX).getString("");
-        final var formats = node.node(FORMATS).get(FormatsHolderImpl.class, new FormatsHolderImpl());
+        final var formatsMap = node.node(FORMATS).get(FORMATS_MAP_TYPE, Map.of());
+        final var formats = new FormatsHolderImpl(formatsMap);
         final var radius = node.node(RADIUS).getInt(-1);
 
         final var channelType = node.node(TYPE).getString("default").toLowerCase();
@@ -71,7 +76,7 @@ public final class ChannelMapper implements TypeSerializer<Channel> {
         target.node(TOGGLE_COMMAND).set(channel.commandNames());
         target.node(MESSAGE_PREFIX).set(channel.messagePrefix());
         target.node(CHANNEL_PREFIX).set(channel.channelPrefix());
-        target.node(FORMATS).set(channel.formats());
+        target.node(FORMATS).set(channel.formats().formats());
         target.node(RADIUS).set(channel.radius());
     }
 }


### PR DESCRIPTION
- Fixed wrong channel formats path. From `channels.<channel-name>.formats.formats.<format-name>` to `channels.<channel-name>.formats.<format-name>`
- Fixed wrong message being sent on /chatchat reload when the number of loaded formats and/or channels were 1
- Added a console warning when the default channel can't be loaded/found to let the user know that an internal channel will be used.
- Listed the number of channel formats that were loaded on /chatchat reload
- Listed the number of formats, channels and channel formats that were loaded on startup (in console)
- Removed the default channel formats. They were only creating confusion for new people.

Tested all the features locally and also just provided a jar in discord for people to test.