### PR TITLE
Configurable extensions

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigFactory.java
@@ -4,11 +4,14 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.format.Format;
 import at.helpch.chatchat.api.format.PriorityFormat;
 import at.helpch.chatchat.api.holder.GlobalFormatsHolder;
+import at.helpch.chatchat.config.holder.AddonsHolder;
 import at.helpch.chatchat.config.holder.ChannelsHolder;
+import at.helpch.chatchat.config.holder.ExtensionsHolder;
 import at.helpch.chatchat.config.holder.GlobalFormatsHolderImpl;
 import at.helpch.chatchat.config.holder.MessagesHolder;
 import at.helpch.chatchat.config.holder.MiniPlaceholdersHolder;
 import at.helpch.chatchat.config.holder.SettingsHolder;
+import at.helpch.chatchat.config.mapper.AddonsMapper;
 import at.helpch.chatchat.config.mapper.SimpleFormatMapper;
 import at.helpch.chatchat.config.mapper.ChannelMapMapper;
 import at.helpch.chatchat.config.mapper.MiniMessageComponentMapper;
@@ -60,6 +63,11 @@ public final class ConfigFactory {
         return Objects.requireNonNullElseGet(config, MessagesHolder::new);
     }
 
+    public @NotNull ExtensionsHolder extensions() {
+        final var config = create(ExtensionsHolder.class, "extensions.yml");
+        return Objects.requireNonNullElseGet(config, ExtensionsHolder::new);
+    }
+
     public @NotNull MiniPlaceholdersHolder miniPlaceholders() {
         final var config = create(MiniPlaceholdersHolder.class, "placeholders.yml");
         return Objects.requireNonNullElseGet(config, MiniPlaceholdersHolder::new);
@@ -104,6 +112,8 @@ public final class ConfigFactory {
                     .register(ChatFormat.class, new PriorityFormatMapper())
 
                     .register(MiniPlaceholderImpl.class, new MiniPlaceholderMapper())
+
+                    .register(AddonsHolder.class, new AddonsMapper())
 
                     .register(new TypeToken<>() {}, new ChannelMapMapper(plugin))
                     .registerAll(ConfigurateComponentSerializer.configurate().serializers())))

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -4,6 +4,7 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.api.holder.GlobalFormatsHolder;
 import at.helpch.chatchat.channel.ChatChannel;
 import at.helpch.chatchat.config.holder.ChannelsHolder;
+import at.helpch.chatchat.config.holder.ExtensionsHolder;
 import at.helpch.chatchat.config.holder.MessagesHolder;
 import at.helpch.chatchat.config.holder.MiniPlaceholdersHolder;
 import at.helpch.chatchat.config.holder.SettingsHolder;
@@ -20,6 +21,7 @@ public final class ConfigManager {
     private GlobalFormatsHolder formats;
     private SettingsHolder settings;
     private MessagesHolder messages;
+    private ExtensionsHolder extensions;
     private MiniPlaceholdersHolder miniPlaceholders;
     private final ConfigFactory factory;
 
@@ -33,9 +35,11 @@ public final class ConfigManager {
         channels = null;
         formats = null;
         settings = null;
+        extensions = null;
         miniPlaceholders = null;
 
         messages();
+        extensions();
 
         channels();
         final var defaultChannel = channels.channels().get(channels.defaultChannel());
@@ -85,6 +89,13 @@ public final class ConfigManager {
             this.messages = factory.messages();
         }
         return this.messages;
+    }
+
+    public @NotNull ExtensionsHolder extensions() {
+        if (extensions == null) {
+            this.extensions = factory.extensions();
+        }
+        return this.extensions;
     }
 
     public @NotNull MiniPlaceholdersHolder miniPlaceholders() {

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -40,6 +40,7 @@ public final class ConfigManager {
 
         messages();
         extensions();
+        plugin.getLogger().info("Whenever making changes to extensions.yml, restart the server to make sure all changes are applied.");
 
         channels();
         final var defaultChannel = channels.channels().get(channels.defaultChannel());

--- a/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/ConfigManager.java
@@ -56,8 +56,16 @@ public final class ConfigManager {
         settings();
 
         formats();
-        final var defaultFormat = formats.formats().getOrDefault(formats.defaultFormat(), DefaultFormatFactory.createDefaultFormat());
-        ChatFormat.defaultFormat(defaultFormat);
+        final var defaultFormat = formats.formats().get(formats.defaultFormat());
+        if (defaultFormat instanceof ChatFormat) {
+            ChatFormat.defaultFormat(defaultFormat);
+        } else {
+            ChatFormat.defaultFormat(DefaultFormatFactory.createDefaultFormat());
+            plugin.getLogger().warning(
+                "Could not find a format named " + formats.defaultFormat() + "." + System.lineSeparator() +
+                    "Using an internal format as the default format."
+            );
+        }
 
         miniPlaceholders();
         miniPlaceholders.placeholders().forEach(placeholder -> plugin.miniPlaceholdersManager().addPlaceholder(placeholder));

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/AddonsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/AddonsHolder.java
@@ -7,7 +7,7 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 public class AddonsHolder {
 
     // DeluxeChat features
-    private boolean DELUXECHAT_INVERSE_PRIORITIES = true;
+    private boolean DELUXECHAT_INVERSE_PRIORITIES = false;
     private boolean DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT = true;
     private boolean DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT = true;
 

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/AddonsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/AddonsHolder.java
@@ -1,0 +1,81 @@
+package at.helpch.chatchat.config.holder;
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+@SuppressWarnings("FieldMayBeFinal")
+@ConfigSerializable
+public class AddonsHolder {
+
+    // DeluxeChat features
+    private boolean DELUXECHAT_INVERSE_PRIORITIES = true;
+    private boolean DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT = true;
+    private boolean DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT = true;
+
+    // Towny features
+    private boolean TOWNY_CHANNELS = false;
+
+    // DiscordSRV features
+    private boolean DISCORDSRV_CHANNELS_BRIDGING = false;
+
+    // Essentials features
+    private boolean ESSENTIALS_VANISH = false;
+
+    // SuperVanish features
+    private boolean SUPERVANISH_VANISH = false;
+
+    public boolean deluxeChatInversePriorities() {
+        return DELUXECHAT_INVERSE_PRIORITIES;
+    }
+
+    public void deluxeChatInversePriorities(final boolean value) {
+        DELUXECHAT_INVERSE_PRIORITIES = value;
+    }
+
+    public boolean deluxeChatUnicodePermissionPublicChat() {
+        return DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT;
+    }
+
+    public void deluxeChatUnicodePermissionPublicChat(final boolean value) {
+        DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT = value;
+    }
+
+    public boolean deluxeChatUnicodePermissionPrivateChat() {
+        return DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT;
+    }
+
+    public void deluxeChatUnicodePermissionPrivateChat(final boolean value) {
+        DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT = value;
+    }
+
+    public boolean townyChannels() {
+        return TOWNY_CHANNELS;
+    }
+
+    public void townyChannels(final boolean value) {
+        TOWNY_CHANNELS = value;
+    }
+
+    public boolean discordSrvChannelsBridging() {
+        return DISCORDSRV_CHANNELS_BRIDGING;
+    }
+
+    public void discordSrvChannelsBridging(final boolean value) {
+        DISCORDSRV_CHANNELS_BRIDGING = value;
+    }
+
+    public boolean essentialsVanish() {
+        return ESSENTIALS_VANISH;
+    }
+
+    public void essentialsVanish(final boolean value) {
+        ESSENTIALS_VANISH = value;
+    }
+
+    public boolean superVanishVanish() {
+        return SUPERVANISH_VANISH;
+    }
+
+    public void superVanishVanish(final boolean value) {
+        SUPERVANISH_VANISH = value;
+    }
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/ExtensionsHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/ExtensionsHolder.java
@@ -1,0 +1,16 @@
+package at.helpch.chatchat.config.holder;
+
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+@SuppressWarnings("FieldMayBeFinal")
+@ConfigSerializable
+public class ExtensionsHolder {
+
+    private AddonsHolder addons = new AddonsHolder();
+
+    public @NotNull AddonsHolder addons() {
+        return addons;
+    }
+
+}

--- a/plugin/src/main/java/at/helpch/chatchat/config/mapper/AddonsMapper.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/mapper/AddonsMapper.java
@@ -1,0 +1,63 @@
+package at.helpch.chatchat.config.mapper;
+
+import at.helpch.chatchat.config.holder.AddonsHolder;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.serialize.SerializationException;
+import org.spongepowered.configurate.serialize.TypeSerializer;
+
+import java.lang.reflect.Type;
+
+public class AddonsMapper implements TypeSerializer<AddonsHolder> {
+
+    private static final Object[] DELUXECHAT_INVERSE_PRIORITIES = new Object[] {"deluxechat", "inverse_priorities"};
+    private static final Object[] DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT = new Object[] {"deluxechat", "unicode_permission", "public_chat"};
+    private static final Object[] DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT = new Object[] {"deluxechat", "unicode_permission", "private_chat"};
+
+    private static final Object[] TOWNY_CHANNELS = new Object[] {"towny", "channels"};
+
+    private static final Object[] DISCORDSRV_CHANNELS_BRIDGING = new Object[] {"discordsrv", "channels_bridging"};
+
+    private static final Object[] ESSENTIALS_VANISH = new Object[] {"essentials", "vanish"};
+
+    private static final Object[] SUPERVANISH_VANISH = new Object[] {"supervanish", "vanish"};
+
+    @Override
+    public AddonsHolder deserialize(final Type type, final ConfigurationNode node) throws SerializationException {
+        final AddonsHolder holder = new AddonsHolder();
+
+        holder.deluxeChatInversePriorities(node.node(DELUXECHAT_INVERSE_PRIORITIES).getBoolean(true));
+        holder.deluxeChatUnicodePermissionPublicChat(node.node(DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT).getBoolean(true));
+        holder.deluxeChatUnicodePermissionPrivateChat(node.node(DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT).getBoolean(true));
+
+        holder.townyChannels(node.node(TOWNY_CHANNELS).getBoolean(false));
+
+        holder.discordSrvChannelsBridging(node.node(DISCORDSRV_CHANNELS_BRIDGING).getBoolean(false));
+
+        holder.essentialsVanish(node.node(ESSENTIALS_VANISH).getBoolean(true));
+
+        holder.superVanishVanish(node.node(SUPERVANISH_VANISH).getBoolean(false));
+
+        return holder;
+    }
+
+    @Override
+    public void serialize(final Type type, final @Nullable AddonsHolder obj, final ConfigurationNode target) throws SerializationException {
+        if (obj == null) {
+            return;
+        }
+
+        target.node(DELUXECHAT_INVERSE_PRIORITIES).set(obj.deluxeChatInversePriorities());
+        target.node(DELUXECHAT_UNICODE_PERMISSION_PUBLIC_CHAT).set(obj.deluxeChatUnicodePermissionPublicChat());
+        target.node(DELUXECHAT_UNICODE_PERMISSION_PRIVATE_CHAT).set(obj.deluxeChatUnicodePermissionPrivateChat());
+
+        target.node(TOWNY_CHANNELS).set(obj.townyChannels());
+
+        target.node(DISCORDSRV_CHANNELS_BRIDGING).set(obj.discordSrvChannelsBridging());
+
+        target.node(ESSENTIALS_VANISH).set(obj.essentialsVanish());
+
+        target.node(SUPERVANISH_VANISH).set(obj.superVanishVanish());
+    }
+
+}

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/HookManagerImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/HookManagerImpl.java
@@ -28,18 +28,10 @@ public final class HookManagerImpl implements HookManager {
         this.plugin = plugin;
         HookCreator hookCreator = new HookCreator(plugin);
         constructors.add(hookCreator::vanillaVanishHook);
-        if (plugin.configManager().extensions().addons().discordSrvChannelsBridging()) {
-            constructors.add(hookCreator::createDsrvHook);
-        }
-        if (plugin.configManager().extensions().addons().townyChannels()) {
-            constructors.add(hookCreator::chatChatTownyHook);
-        }
-        if (plugin.configManager().extensions().addons().essentialsVanish()) {
-            constructors.add(hookCreator::essentialsVanishHook);
-        }
-        if (plugin.configManager().extensions().addons().superVanishVanish()) {
-            constructors.add(hookCreator::superVanishHook);
-        }
+        constructors.add(hookCreator::createDsrvHook);
+        constructors.add(hookCreator::chatChatTownyHook);
+        constructors.add(hookCreator::essentialsVanishHook);
+        constructors.add(hookCreator::superVanishHook);
     }
 
     public void init() {

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/HookManagerImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/HookManagerImpl.java
@@ -27,11 +27,19 @@ public final class HookManagerImpl implements HookManager {
     public HookManagerImpl(final @NotNull ChatChatPlugin plugin) {
         this.plugin = plugin;
         HookCreator hookCreator = new HookCreator(plugin);
-        constructors.add(hookCreator::createDsrvHook);
-        constructors.add(hookCreator::chatChatTownyHook);
         constructors.add(hookCreator::vanillaVanishHook);
-        constructors.add(hookCreator::essentialsVanishHook);
-        constructors.add(hookCreator::superVanishHook);
+        if (plugin.configManager().extensions().addons().discordSrvChannelsBridging()) {
+            constructors.add(hookCreator::createDsrvHook);
+        }
+        if (plugin.configManager().extensions().addons().townyChannels()) {
+            constructors.add(hookCreator::chatChatTownyHook);
+        }
+        if (plugin.configManager().extensions().addons().essentialsVanish()) {
+            constructors.add(hookCreator::essentialsVanishHook);
+        }
+        if (plugin.configManager().extensions().addons().superVanishVanish()) {
+            constructors.add(hookCreator::superVanishHook);
+        }
     }
 
     public void init() {

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/ChatChatDsrvHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/ChatChatDsrvHook.java
@@ -4,10 +4,10 @@ import at.helpch.chatchat.ChatChatPlugin;
 import at.helpch.chatchat.hooks.AbstractInternalHook;
 import github.scarsz.discordsrv.DiscordSRV;
 import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 public final class ChatChatDsrvHook extends AbstractInternalHook {
+
     private static final String DISCORD_SRV = "DiscordSRV";
 
     private final ChatChatPlugin plugin;
@@ -19,7 +19,8 @@ public final class ChatChatDsrvHook extends AbstractInternalHook {
 
     @Override
     public boolean register() {
-        return Bukkit.getPluginManager().isPluginEnabled(DISCORD_SRV);
+        return plugin.configManager().extensions().addons().discordSrvChannelsBridging() &&
+            Bukkit.getPluginManager().isPluginEnabled(DISCORD_SRV);
     }
 
     @Override
@@ -33,4 +34,5 @@ public final class ChatChatDsrvHook extends AbstractInternalHook {
         DiscordSRV.getPlugin().getPluginHooks().add(hook);
         Bukkit.getPluginManager().registerEvents(hook, plugin);
     }
+
 }

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/towny/ChatChatTownyHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/towny/ChatChatTownyHook.java
@@ -1,10 +1,8 @@
 package at.helpch.chatchat.hooks.towny;
 
 import at.helpch.chatchat.ChatChatPlugin;
-import at.helpch.chatchat.api.hook.Hook;
 import at.helpch.chatchat.hooks.AbstractInternalHook;
 import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 public class ChatChatTownyHook extends AbstractInternalHook {
@@ -20,7 +18,8 @@ public class ChatChatTownyHook extends AbstractInternalHook {
 
     @Override
     public boolean register() {
-        return Bukkit.getPluginManager().isPluginEnabled(TOWNY);
+        return plugin.configManager().extensions().addons().townyChannels() &&
+            Bukkit.getPluginManager().isPluginEnabled(TOWNY);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/EssentialsVanishHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/EssentialsVanishHook.java
@@ -29,7 +29,8 @@ public class EssentialsVanishHook extends AbstractInternalVanishHook {
 
     @Override
     public boolean register() {
-        return Bukkit.getPluginManager().isPluginEnabled(ESSENTIALS);
+        return plugin.configManager().extensions().addons().essentialsVanish() &&
+            Bukkit.getPluginManager().isPluginEnabled(ESSENTIALS);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/SuperVanishHook.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/vanish/SuperVanishHook.java
@@ -32,8 +32,8 @@ public class SuperVanishHook extends AbstractInternalVanishHook {
 
     @Override
     public boolean register() {
-        return Bukkit.getPluginManager().isPluginEnabled(SUPER_VANISH) ||
-            Bukkit.getPluginManager().isPluginEnabled(PREMIUM_VANISH);
+        return plugin.configManager().extensions().addons().superVanishVanish() &&
+            (Bukkit.getPluginManager().isPluginEnabled(SUPER_VANISH) || Bukkit.getPluginManager().isPluginEnabled(PREMIUM_VANISH));
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/rule/RuleManagerImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/rule/RuleManagerImpl.java
@@ -22,8 +22,12 @@ public class RuleManagerImpl implements RuleManager {
 
     public RuleManagerImpl(@NotNull final ChatChatPlugin plugin) {
         this.plugin = plugin;
-        addPublicChatRule(new InvalidCharsRule(plugin));
-        addPrivateChatRule(new InvalidCharsRule(plugin));
+        if (plugin.configManager().extensions().addons().deluxeChatUnicodePermissionPublicChat()) {
+            addPublicChatRule(new InvalidCharsRule(plugin));
+        }
+        if (plugin.configManager().extensions().addons().deluxeChatUnicodePermissionPrivateChat()) {
+            addPrivateChatRule(new InvalidCharsRule(plugin));
+        }
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -73,7 +73,11 @@ public final class MessageProcessor {
         final var chatEvent = new ChatChatEvent(
             async,
             user,
-            FormatUtils.findFormat(user.player(), channel, plugin.configManager().formats()),
+            FormatUtils.findFormat(
+                user.player(),
+                channel,
+                plugin.configManager().formats(),
+                plugin.configManager().extensions().addons().deluxeChatInversePriorities()),
             // TODO: 9/2/22 Process message for each recipient to add rel support inside the message itself.
             //  Possibly even pass the minimessage string here instead of the processed component.
             MessageProcessor.processMessage(plugin, user, ConsoleUser.INSTANCE, message),

--- a/plugin/src/main/resources/extensions.yml
+++ b/plugin/src/main/resources/extensions.yml
@@ -1,0 +1,27 @@
+# Any changes made to the addons require a server restart to take effect.
+addons:
+  deluxechat:
+    # If enabled, lower numbers mean higher priority just like in DeluxeChat.
+    inverse_priorities: true
+    # Enable or disable the Unicode Characters rule. This rule only allows people to use non ascii characters if they
+    # have the permission "chatchat.utf" just like in DeluxeChat.
+    unicode_permission:
+      # Enable the rule for public messages.
+      public_chat: true
+      # Enable the rule for private messages.
+      private_chat: true
+  towny:
+    # Enable or disable the towny town and nation channel types. If enabled, TOWNY_TOWN and TOWNY_NATION can be used as channel type.
+    channels: false
+  discordsrv:
+    # Enable or disable DiscordSRV support. If enabled, ChatChat channels and DiscordSRV channels that have the same
+    # name will be bridged.
+    # NOTE: DiscordSRV channel names are not the same as Discord channel names! They are the names set in the DiscordSRV
+    # config.
+    channels_bridging: false
+  essentials:
+    # Enable or disable support for Essentials' vanish system.
+    vanish: true
+  supervanish:
+    # Enable or disable support for SuperVanish's vanish system.
+    vanish: false

--- a/plugin/src/main/resources/extensions.yml
+++ b/plugin/src/main/resources/extensions.yml
@@ -2,7 +2,7 @@
 addons:
   deluxechat:
     # If enabled, lower numbers mean higher priority just like in DeluxeChat.
-    inverse_priorities: true
+    inverse_priorities: false
     # Enable or disable the Unicode Characters rule. This rule only allows people to use non ascii characters if they
     # have the permission "chatchat.utf" just like in DeluxeChat.
     unicode_permission:


### PR DESCRIPTION
Added a new `extensions.yml` file. From that file, users can enable or disable certain features of ChatChat. These features are mostly addons that add compatibility with other plugins but also extra features that are made to replicate the way another plugin works.

A few examples:
- DeluxeChat inverse priorities - in [DeluxeChat](https://www.spigotmc.org/resources/1277/), lower number = higher priority and this can be replicated in ChatChat
- DeluxeChat utf-8 rule - in [DeluxeChat](https://www.spigotmc.org/resources/1277/), using non ASCII characters is locked behind a permission. This can be replicated in ChatChat
- Towny addon - adds ability to create [Towny](https://github.com/TownyAdvanced/Towny) nation and town channels.
- DiscordSRV addon - adds support for cross platform (Minecraft to Discord and vice versa) messaging thru [DiscordSRV](https://github.com/DiscordSRV/DiscordSRV)
- EssentialsX addon - adds support for [EssentialsX](https://github.com/EssentialsX/Essentials/)'s vanish system for hiding players.
- SuperVanish addon - Adds support for [SuperVanish](https://github.com/LeonMangler/SuperVanish) and [PremiumVanish](https://www.spigotmc.org/resources/14404/)'s vanish system.

Closes #188 