### PR TITLE
1.20.2 support (updated adventure)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -6,6 +6,11 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
+repositories {
+    // adventure snapshot repo
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+}
+
 dependencies {
     api(libs.adventure.bukkit)
     api(libs.adventure.minimessage)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ spigot = "1.20.1-R0.1-SNAPSHOT"
 
 # Adventure
 minimessage = "4.14.0"
-adventure-platform = "4.3.0"
+adventure-platform = "4.3.2-SNAPSHOT"
 
 # Other
 configurate = "4.1.2"
@@ -12,7 +12,7 @@ cmds = "2.0.0-SNAPSHOT"
 papi = "2.11.1"
 towny = "0.98.1.3"
 discordsrv = "1.25.1"
-supervanish = "6.2.6-4"
+supervanish = "6.2.17"
 bstats = "3.0.0"
 essentials = "2.19.4"
 griefprevention = "16.18.1"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -12,6 +12,8 @@ version = "${rootProject.version}-${System.getenv("BUILD_NUMBER")}"
 repositories {
     papi()
     triumphSnapshots()
+    // adventure snapshot repo
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     // towny
     maven("https://repo.glaremasters.me/repository/towny/")
     // dsrv + dependencies


### PR DESCRIPTION
updated adventure lib to support 1.20.2
supervanish also needed to be updated as the old version failed to build