### PR TITLE
Add 1.20.x support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 spigot = "1.20.1-R0.1-SNAPSHOT"
 
 # Adventure
-minimessage = "4.14.0"
-adventure-platform = "4.3.2-SNAPSHOT"
+minimessage = "4.15.0"
+adventure-platform = "4.3.2"
 
 # Other
 configurate = "4.1.2"


### PR DESCRIPTION
It seems that only hover was broken on 1.20.4. Tested on 1.20.4, basic features (including hover) work.