### PR TITLE
Resolve #218

### DIFF
--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -57,6 +57,6 @@ public final class SwitchChannelCommand extends BaseCommand {
             return;
         }
 
-        MessageProcessor.process(plugin, user, channel, user.channel(), message, false);
+        MessageProcessor.process(plugin, user, channel, message, false);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/SwitchChannelCommand.java
@@ -57,6 +57,6 @@ public final class SwitchChannelCommand extends BaseCommand {
             return;
         }
 
-        MessageProcessor.process(plugin, user, channel, message, false);
+        MessageProcessor.process(plugin, user, channel, user.channel(), message, false);
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -101,14 +101,8 @@ public final class ChatListener implements Listener {
 
         // Cancel the event if the message doesn't end up being sent
         // This only happens if the message contains illegal characters or if the ChatChatEvent is canceled.
-        boolean cancelled = MessageProcessor.process(plugin, user, channel, oldChannel, message, event.isAsynchronous());
-
-        event.setCancelled(!cancelled);
-
-        // If the event was cancelled, we need to reset the user back to their old channel
-        if(cancelled) {
-            user.channel(oldChannel);
-        }
+        event.setCancelled(!MessageProcessor.process(plugin, user, channel, message, event.isAsynchronous()));
+        user.channel(oldChannel);
     }
 
     private static String cleanseMessage(@NotNull final String message) {

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -113,6 +113,7 @@ public final class MessageProcessor {
             return false;
         }
 
+        final var oldChannel = user.channel();
         user.channel(channel);
 
         final var parsedMessage = chatEvent.message().compact();
@@ -182,6 +183,7 @@ public final class MessageProcessor {
         }
 
         if (!userIsTarget) {
+            user.channel(oldChannel);
             return true;
         }
 
@@ -207,6 +209,7 @@ public final class MessageProcessor {
             user.playSound(mentions.sound());
         }
 
+        user.channel(oldChannel);
         return true;
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -59,10 +59,23 @@ public final class MessageProcessor {
         throw new AssertionError("Util classes are not to be instantiated!");
     }
 
+    /**
+     * Process a message for a user and send it to the recipients.
+     * @param plugin The plugin instance.
+     * @param user The user sending the message.
+     * @param channel The channel the user is sending the message to.
+     * @param previousChannel The previous channel the user was in. Used to switch back to after sending the message.
+     *                        Used to switch back when sending a message to a channel with a prefix.
+     * @param message The message to send.
+     * @param async Whether to process the message asynchronously.
+     *
+     * @return Whether the message was sent successfully.
+     */
     public static boolean process(
         @NotNull final ChatChatPlugin plugin,
         @NotNull final ChatUser user,
         @NotNull final Channel channel,
+        @NotNull final Channel previousChannel,
         @NotNull final String message,
         final boolean async
     ) {
@@ -103,7 +116,6 @@ public final class MessageProcessor {
             return false;
         }
 
-        final var oldChannel = user.channel();
         user.channel(channel);
 
         final var parsedMessage = chatEvent.message().compact();
@@ -173,7 +185,7 @@ public final class MessageProcessor {
         }
 
         if (!userIsTarget) {
-            user.channel(oldChannel);
+            user.channel(previousChannel);
             return true;
         }
 
@@ -199,7 +211,7 @@ public final class MessageProcessor {
             user.playSound(mentions.sound());
         }
 
-        user.channel(oldChannel);
+        user.channel(previousChannel);
         return true;
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MessageProcessor.java
@@ -64,8 +64,6 @@ public final class MessageProcessor {
      * @param plugin The plugin instance.
      * @param user The user sending the message.
      * @param channel The channel the user is sending the message to.
-     * @param previousChannel The previous channel the user was in. Used to switch back to after sending the message.
-     *                        Used to switch back when sending a message to a channel with a prefix.
      * @param message The message to send.
      * @param async Whether to process the message asynchronously.
      *
@@ -75,7 +73,6 @@ public final class MessageProcessor {
         @NotNull final ChatChatPlugin plugin,
         @NotNull final ChatUser user,
         @NotNull final Channel channel,
-        @NotNull final Channel previousChannel,
         @NotNull final String message,
         final boolean async
     ) {
@@ -185,7 +182,6 @@ public final class MessageProcessor {
         }
 
         if (!userIsTarget) {
-            user.channel(previousChannel);
             return true;
         }
 
@@ -211,7 +207,6 @@ public final class MessageProcessor {
             user.playSound(mentions.sound());
         }
 
-        user.channel(previousChannel);
         return true;
     }
 


### PR DESCRIPTION
Resolves issue #218

In the console format for ChatChat, if I use %chatchat_channel_name% - it always returns default, unless the person is in the dedicated channel.

I have a staff chat - and you can use /staff or use the @ prefix to send a message.

However, If I use the prefix, the message will successfully go to console and the proper chat in-game, but the %chatchat_channel_name% still returns default channel in console format, rather than staff channel.
