### PR TITLE
Fix issues introduced in PR #232

### DIFF
--- a/api/src/main/java/at/helpch/chatchat/api/user/ChatUser.java
+++ b/api/src/main/java/at/helpch/chatchat/api/user/ChatUser.java
@@ -19,14 +19,6 @@ public interface ChatUser extends User {
     @NotNull Optional<Player> player();
 
     /**
-     * Gets the player that this user is backed by. If the player is not present, an exception is thrown.
-     *
-     * @return The player that this user is backed by.
-     * @throws NullPointerException If the player is not present.
-     */
-    @NotNull Player playerNotNull() throws NullPointerException;
-
-    /**
      * Gets the user that this user has last sent a private message to.
      *
      * @return The last messaged user.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 spigot = "1.20.1-R0.1-SNAPSHOT"
 
 # Adventure
-minimessage = "4.15.0"
-adventure-platform = "4.3.2"
+minimessage = "4.16.0"
+adventure-platform = "4.3.3-SNAPSHOT"
 
 # Other
 configurate = "4.1.2"

--- a/plugin/src/main/java/at/helpch/chatchat/command/FormatTestCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/FormatTestCommand.java
@@ -29,6 +29,12 @@ public class FormatTestCommand extends ChatChatCommand {
         @NotNull final PriorityFormat format,
         @Join @NotNull final String message
     ) {
+        var player = sender.player();
+        if (player.isEmpty()) {
+            sender.sendMessage(plugin.configManager().messages().genericError());
+            return;
+        }
+
         if (message.isBlank()) {
             sender.sendMessage(plugin.configManager().messages().emptyMessage());
             return;
@@ -37,8 +43,8 @@ public class FormatTestCommand extends ChatChatCommand {
         sender.sendMessage(
             FormatUtils.parseFormat(
                 format,
-                sender.playerNotNull(),
-                sender.playerNotNull(),
+                player.get(),
+                player.get(),
                 MessageProcessor.processMessage(plugin, sender, ConsoleUser.INSTANCE, message),
                 plugin.miniPlaceholdersManager().compileTags(MiniPlaceholderContext.builder().inMessage(false).sender(sender).recipient(sender).build())
             )

--- a/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/IgnoreCommand.java
@@ -26,14 +26,20 @@ public class IgnoreCommand extends BaseCommand {
             return;
         }
 
+        var targetPlayer = target.player();
+        if (targetPlayer.isEmpty()) {
+            sender.sendMessage(plugin.configManager().messages().userOffline());
+            return;
+        }
+
         if (sender.ignoredUsers().contains(target.uuid())) {
             sender.sendMessage(plugin.configManager().messages().alreadyIgnored()
-                .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.playerNotNull().getDisplayName())));
+                .replaceText(builder -> builder.matchLiteral("<player>").replacement(targetPlayer.get().getDisplayName())));
             return;
         }
 
         sender.ignoreUser(target);
         sender.sendMessage(plugin.configManager().messages().ignoredPlayer()
-            .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.playerNotNull().getDisplayName())));
+            .replaceText(builder -> builder.matchLiteral("<player>").replacement(targetPlayer.get().getDisplayName())));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/UnignoreCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/UnignoreCommand.java
@@ -20,14 +20,20 @@ public class UnignoreCommand extends BaseCommand {
     @Permission(IGNORE_PERMISSION)
     @Default
     public void unignore(ChatUser sender, ChatUser target) {
+        var targetPlayer = target.player();
+        if (targetPlayer.isEmpty()) {
+            sender.sendMessage(plugin.configManager().messages().userOffline());
+            return;
+        }
+
         if (!sender.ignoredUsers().contains(target.uuid())) {
             sender.sendMessage(plugin.configManager().messages().notIgnored()
-                .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.playerNotNull().getDisplayName())));
+                .replaceText(builder -> builder.matchLiteral("<player>").replacement(targetPlayer.get().getDisplayName())));
             return;
         }
 
         sender.unignoreUser(target);
         sender.sendMessage(plugin.configManager().messages().unignoredPlayer()
-            .replaceText(builder -> builder.matchLiteral("<player>").replacement(target.playerNotNull().getDisplayName())));
+            .replaceText(builder -> builder.matchLiteral("<player>").replacement(targetPlayer.get().getDisplayName())));
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
+++ b/plugin/src/main/java/at/helpch/chatchat/command/WhisperCommand.java
@@ -37,6 +37,13 @@ public final class WhisperCommand extends BaseCommand {
         @Suggestion(value = "recipients") final ChatUser recipient,
         @Join final String message
     ) {
+        var senderPlayer = sender.player();
+        var recipientPlayer = recipient.player();
+        if (senderPlayer.isEmpty() || recipientPlayer.isEmpty()) {
+            sender.sendMessage(plugin.configManager().messages().userOffline());
+            return;
+        }
+
         if (!plugin.configManager().settings().privateMessagesSettings().enabled()) {
             sender.sendMessage(plugin.configManager().messages().unknownCommand());
             return;
@@ -123,8 +130,8 @@ public final class WhisperCommand extends BaseCommand {
         formats.forEach((Audience audience, Format format) ->
             audience.sendMessage(FormatUtils.parseFormat(
                 format,
-                sender.playerNotNull(),
-                recipient.playerNotNull(),
+                senderPlayer.get(),
+                recipientPlayer.get(),
                 pmSendEvent.message()
             ))
         );

--- a/plugin/src/main/java/at/helpch/chatchat/config/holder/MessagesHolder.java
+++ b/plugin/src/main/java/at/helpch/chatchat/config/holder/MessagesHolder.java
@@ -73,6 +73,9 @@ public final class MessagesHolder {
     // format related
     private Component invalidFormat = text("Invalid format.", RED);
 
+    // generic
+    private Component genericError = text("An unexpected error occurred!", RED);
+
     public @NotNull Component consoleOnly() {
         return consoleOnly;
     }
@@ -235,6 +238,10 @@ public final class MessagesHolder {
 
     public @NotNull Component chatDisabled() {
         return chatDisabled;
+    }
+
+    public @NotNull Component genericError() {
+        return genericError;
     }
 
 }

--- a/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/DsrvListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/hooks/dsrv/DsrvListener.java
@@ -43,10 +43,14 @@ public final class DsrvListener implements ChatHook {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onChat(ChatChatEvent event) {
+        var player = event.user().player();
+        if (player.isEmpty()) {
+            return;
+        }
+
         final var message = github.scarsz.discordsrv.dependencies.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson().deserialize(
                 GsonComponentSerializer.gson().serialize(event.message())
         );
-        DiscordSRV.getPlugin().processChatMessage(event.user().playerNotNull(), message,
-                event.channel().name(), event.isCancelled());
+        DiscordSRV.getPlugin().processChatMessage(player.get(), message, event.channel().name(), event.isCancelled());
     }
 }

--- a/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
+++ b/plugin/src/main/java/at/helpch/chatchat/listener/ChatListener.java
@@ -99,9 +99,12 @@ public final class ChatListener implements Listener {
                     "format are installed and work properly.");
         }
 
+        var sent = MessageProcessor.process(plugin, user, channel, message, event.isAsynchronous());
         // Cancel the event if the message doesn't end up being sent
         // This only happens if the message contains illegal characters or if the ChatChatEvent is canceled.
-        event.setCancelled(!MessageProcessor.process(plugin, user, channel, message, event.isAsynchronous()));
+        if (!event.isCancelled() && !sent) {
+            event.setCancelled(false);
+        }
         user.channel(oldChannel);
     }
 

--- a/plugin/src/main/java/at/helpch/chatchat/placeholder/PlaceholderAPIPlaceholders.java
+++ b/plugin/src/main/java/at/helpch/chatchat/placeholder/PlaceholderAPIPlaceholders.java
@@ -7,9 +7,11 @@ import me.clip.placeholderapi.PlaceholderAPIPlugin;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import net.kyori.adventure.identity.Identity;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public final class PlaceholderAPIPlaceholders extends PlaceholderExpansion {
     private final ChatChatPlugin plugin;
@@ -85,7 +87,7 @@ public final class PlaceholderAPIPlaceholders extends PlaceholderExpansion {
             case "private_messages_enabled":
                 return formatBoolean(chatUser.privateMessages());
             case "private_messages_recipient":
-                return chatUser.lastMessagedUser().map(value -> value.playerNotNull().getName()).orElse("");
+                return chatUser.lastMessagedUser().map(value -> value.player().map(Player::getName).orElse("")).orElse("");
         }
 
         return null;

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -8,6 +8,7 @@ import at.helpch.chatchat.api.user.User;
 import at.helpch.chatchat.cache.ExpiringCache;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -20,6 +21,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
 
 public final class ChatUserImpl implements ChatUser {
 
@@ -173,15 +178,8 @@ public final class ChatUserImpl implements ChatUser {
     }
 
     @Override
-    public @NotNull Player playerNotNull() throws NullPointerException {
-        return player().orElseThrow(() -> new NullPointerException("Player is not present!"));
-    }
-
-    @Override
     public @NotNull Audience audience() {
-        try (var audiences = ChatChatPlugin.audiences()) {
-            return audiences.player(uuid);
-        }
+        return ChatChatPlugin.audiences().player(uuid);
     }
 
     @Override

--- a/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
+++ b/plugin/src/main/java/at/helpch/chatchat/user/ChatUserImpl.java
@@ -8,7 +8,6 @@ import at.helpch.chatchat.api.user.User;
 import at.helpch.chatchat.cache.ExpiringCache;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -21,10 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.GREEN;
-import static net.kyori.adventure.text.format.NamedTextColor.RED;
 
 public final class ChatUserImpl implements ChatUser {
 

--- a/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/ChannelUtils.java
@@ -52,8 +52,15 @@ public final class ChannelUtils {
         }
 
         if (radius != -1 && source instanceof ChatUser) {
-            final Location sourceLocation = ((ChatUser) source).playerNotNull().getLocation();
-            final Location targetLocation = ((ChatUser) target).playerNotNull().getLocation();
+            var sourcePlayer = ((ChatUser) source).player();
+            var targetPlayer = ((ChatUser) target).player();
+
+            if (sourcePlayer.isEmpty() || targetPlayer.isEmpty()) {
+                return false;
+            }
+
+            final Location sourceLocation = sourcePlayer.get().getLocation();
+            final Location targetLocation = targetPlayer.get().getLocation();
 
             final World sourceWorld = sourceLocation.getWorld();
             final World targetWorld = targetLocation.getWorld();

--- a/plugin/src/main/java/at/helpch/chatchat/util/MentionUtils.java
+++ b/plugin/src/main/java/at/helpch/chatchat/util/MentionUtils.java
@@ -84,8 +84,9 @@ public final class MentionUtils {
         @NotNull final Component component,
         @NotNull final Format format
     ) {
-        return replaceMention(prefix + user.playerNotNull(), component,
-            r -> FormatUtils.parseFormat(format, user.playerNotNull(), component));
+        return user.player()
+            .map(value -> replaceMention(prefix + value.getName(), component, r -> FormatUtils.parseFormat(format, value, component)))
+            .orElseGet(() -> new MentionReplaceResult(false, component));
     }
 
     public static @NotNull Map.Entry<@NotNull Boolean, @NotNull Component> processChannelMentions(

--- a/plugin/src/main/resources/messages.yml
+++ b/plugin/src/main/resources/messages.yml
@@ -39,3 +39,5 @@ channel-mentions-enabled: "<green>Successfully enabled channel mentions!"
 channel-mentions-disabled: "<green>Successfully disabled channel mentions!"
 
 invalid-format: "<red>Invalid format!"
+
+generic-error: "<red>An unexpected error occurred!"


### PR DESCRIPTION
- removes ChatUser#playerNotNull in favor of using the ChatUser#player method which returns an optional (as discussed here: https://github.com/HelpChat/ChatChat/pull/232#issuecomment-2079066457)
- upgrades adventure (for 1.20.5 and 1.20.6 support)
- fixes 2 bugs introduced in PR #232:
  - Player#toString being used instead of Player#getName in mention parsing which led to a regex exception being thrown
  - ChatChatPlugin#audiences being used in a try block resulted in it being closed after the first use
  
Tested on:
- `git-Paper-496 (MC: 1.20.4)`
- `Java 17 (OpenJDK 64-Bit Server VM 17.0.5+8)`
- `Linux 5.15.146.1-microsoft-standard-WSL2 (amd64)`